### PR TITLE
Add SNATCH_WITH_EXCEPTIONS, improve API, and reporting of skipped tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SNATCH_MAX_MATCHER_MSG_LENGTH 1024 CACHE STRING "Maximum length of matcher e
 set(SNATCH_MAX_TEST_NAME_LENGTH   1024 CACHE STRING "Maximum length of a test case name.")
 set(SNATCH_MAX_UNIQUE_TAGS        1024 CACHE STRING "Maximum number of unique tags in a test application.")
 set(SNATCH_DEFINE_MAIN            ON   CACHE BOOL   "Define main() in snatch -- disable to provide your own main() function.")
+set(SNATCH_WITH_EXCEPTIONS        ON   CACHE BOOL   "Use exceptions in snatch implementation -- will be force OFF if exceptions are not available.")
 
 add_library(snatch ${PROJECT_SOURCE_DIR}/src/snatch.cpp)
 
@@ -24,7 +25,8 @@ target_compile_definitions(snatch PUBLIC
   SNATCH_MAX_MATCHER_MSG_LENGTH=${SNATCH_MAX_MATCHER_MSG_LENGTH}
   SNATCH_MAX_TEST_NAME_LENGTH=${SNATCH_MAX_TEST_NAME_LENGTH}
   SNATCH_MAX_UNIQUE_TAGS=${SNATCH_MAX_UNIQUE_TAGS}
-  SNATCH_DEFINE_MAIN=$<BOOL:${SNATCH_DEFINE_MAIN}>)
+  SNATCH_DEFINE_MAIN=$<BOOL:${SNATCH_DEFINE_MAIN}>
+  SNATCH_WITH_EXCEPTIONS=$<BOOL:${SNATCH_WITH_EXCEPTIONS}>)
 
 install(FILES ${PROJECT_SOURCE_DIR}/include/snatch/snatch.hpp
   DESTINATION ${CMAKE_INSTALL_PREFIX}/include/snatch)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SNATCH_MAX_TEST_NAME_LENGTH   1024 CACHE STRING "Maximum length of a test ca
 set(SNATCH_MAX_UNIQUE_TAGS        1024 CACHE STRING "Maximum number of unique tags in a test application.")
 set(SNATCH_DEFINE_MAIN            ON   CACHE BOOL   "Define main() in snatch -- disable to provide your own main() function.")
 set(SNATCH_WITH_EXCEPTIONS        ON   CACHE BOOL   "Use exceptions in snatch implementation -- will be force OFF if exceptions are not available.")
+set(SNATCH_WITH_SHORTHAND_MACROS  ON   CACHE BOOL   "Use short names for test macros -- disable if this causes conflicts.")
 
 add_library(snatch ${PROJECT_SOURCE_DIR}/src/snatch.cpp)
 
@@ -26,7 +27,8 @@ target_compile_definitions(snatch PUBLIC
   SNATCH_MAX_TEST_NAME_LENGTH=${SNATCH_MAX_TEST_NAME_LENGTH}
   SNATCH_MAX_UNIQUE_TAGS=${SNATCH_MAX_UNIQUE_TAGS}
   SNATCH_DEFINE_MAIN=$<BOOL:${SNATCH_DEFINE_MAIN}>
-  SNATCH_WITH_EXCEPTIONS=$<BOOL:${SNATCH_WITH_EXCEPTIONS}>)
+  SNATCH_WITH_EXCEPTIONS=$<BOOL:${SNATCH_WITH_EXCEPTIONS}>
+  SNATCH_WITH_SHORTHAND_MACROS=$<BOOL:${SNATCH_WITH_SHORTHAND_MACROS}>)
 
 install(FILES ${PROJECT_SOURCE_DIR}/include/snatch/snatch.hpp
   DESTINATION ${CMAKE_INSTALL_PREFIX}/include/snatch)

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -321,6 +321,7 @@ void registry::run(test_case& t) noexcept {
     t.tests = 0;
     t.state = test_state::success;
 
+#if SNATCH_WITH_EXCEPTIONS
     try {
         t.func(t);
     } catch (const test_state& s) {
@@ -337,6 +338,9 @@ void registry::run(test_case& t) noexcept {
         print_details("unhandled unknown exception caught");
         t.state = test_state::failed;
     }
+#else
+    t.func(t);
+#endif
 
     if (verbose) {
         std::printf("%sfinished:%s %s", color::status_start, color::reset, color::highlight1_start);

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -36,6 +36,7 @@ bool run_tests(registry& r, F&& predicate) noexcept {
     bool        success         = true;
     std::size_t run_count       = 0;
     std::size_t fail_count      = 0;
+    std::size_t skip_count      = 0;
     std::size_t assertion_count = 0;
 
     for (test_case& t : r) {
@@ -50,19 +51,28 @@ bool run_tests(registry& r, F&& predicate) noexcept {
         if (t.state == test_state::failed) {
             ++fail_count;
             success = false;
+        } else if (t.state == test_state::skipped) {
+            ++skip_count;
         }
     }
 
     std::printf("==========================================\n");
+
     if (success) {
         std::printf(
-            "%ssuccess:%s all tests passed (%zu test cases, %zu assertions)\n", color::pass_start,
+            "%ssuccess:%s all tests passed (%zu test cases, %zu assertions", color::pass_start,
             color::reset, run_count, assertion_count);
     } else {
         std::printf(
-            "%serror:%s some tests failed (%zu out of %zu test cases, %zu assertions)\n",
+            "%serror:%s some tests failed (%zu out of %zu test cases, %zu assertions",
             color::fail_start, color::reset, fail_count, run_count, assertion_count);
     }
+
+    if (skip_count > 0) {
+        std::printf(", %zu test cases skipped", skip_count);
+    }
+
+    std::printf(")\n");
 
     return success;
 }


### PR DESCRIPTION
This PR does:
 - Add `SNATCH_WITH_EXCEPTIONS` to enable/disable exceptions in the implementation.
 - Add guards to disable `try`/`catch` blocks when exceptions are not available.
 - Add `SNATCH_WITH_SHORTHAND_MACROS` to enable short macro names, otherwise use `SNATCH_` prefix.
 - Show number of skipped tests in the final report.