### PR TITLE
CMake configuration and benchmark update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,3 +32,23 @@ target_compile_definitions(snatch PUBLIC
 
 install(FILES ${PROJECT_SOURCE_DIR}/include/snatch/snatch.hpp
   DESTINATION ${CMAKE_INSTALL_PREFIX}/include/snatch)
+
+install(TARGETS snatch EXPORT snatch-targets)
+
+install(EXPORT snatch-targets
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/cmake/snatch COMPONENT Development)
+
+export(EXPORT snatch-targets)
+
+# Setup CMake config file
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+  "${PROJECT_SOURCE_DIR}/cmake/snatch-config.cmake.in"
+  "${PROJECT_BINARY_DIR}/snatch-config.cmake"
+  INSTALL_DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO
+  NO_SET_AND_CHECK_MACRO)
+
+install(FILES
+  "${PROJECT_BINARY_DIR}/snatch-config.cmake"
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/cmake/snatch COMPONENT Development)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SNATCH_MAX_TEST_NAME_LENGTH   1024 CACHE STRING "Maximum length of a test ca
 set(SNATCH_MAX_UNIQUE_TAGS        1024 CACHE STRING "Maximum number of unique tags in a test application.")
 set(SNATCH_DEFINE_MAIN            ON   CACHE BOOL   "Define main() in snatch -- disable to provide your own main() function.")
 set(SNATCH_WITH_EXCEPTIONS        ON   CACHE BOOL   "Use exceptions in snatch implementation -- will be force OFF if exceptions are not available.")
+set(SNATCH_WITH_SHORTHAND_MACROS  ON   CACHE BOOL   "Use short names for test macros -- disable if this causes conflicts.")
 
 add_library(snatch ${PROJECT_SOURCE_DIR}/src/snatch.cpp)
 
@@ -26,7 +27,8 @@ target_compile_definitions(snatch PUBLIC
   SNATCH_MAX_TEST_NAME_LENGTH=${SNATCH_MAX_TEST_NAME_LENGTH}
   SNATCH_MAX_UNIQUE_TAGS=${SNATCH_MAX_UNIQUE_TAGS}
   SNATCH_DEFINE_MAIN=$<BOOL:${SNATCH_DEFINE_MAIN}>
-  SNATCH_WITH_EXCEPTIONS=$<BOOL:${SNATCH_WITH_EXCEPTIONS}>)
+  SNATCH_WITH_EXCEPTIONS=$<BOOL:${SNATCH_WITH_EXCEPTIONS}>
+  SNATCH_WITH_SHORTHAND_MACROS=$<BOOL:${SNATCH_WITH_SHORTHAND_MACROS}>)
 
 install(FILES ${PROJECT_SOURCE_DIR}/include/snatch/snatch.hpp
   DESTINATION ${CMAKE_INSTALL_PREFIX}/include/snatch)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The goal of _snatch_ is to be a simple, cheap, non-invasive, and user-friendly t
      - Macro to mark a test as skipped: `SKIP(msg)`.
      - Matchers use a different API (see [Matchers](#matchers) below).
 
-If you need features that are not in the list above, please use _Catch2_.
+If you need features that are not in the list above, please use _Catch2_ or _doctest_.
 
 Notable current limitations:
 
@@ -88,24 +88,27 @@ Output:
 
 ## Benchmark
 
-The following benchmark was done using tests from another library ([observable_unique_ptr](https://github.com/cschreib/observable_unique_ptr)), which generates about 4000 test cases and 25000 checks. Building and running the tests was done without parallelism to simplify the comparison. The benchmarks were ran on a desktop with the following specs:
+The following benchmarks were done using real-world tests from another library ([observable_unique_ptr](https://github.com/cschreib/observable_unique_ptr)), which generates about 4000 test cases and 25000 checks. This library uses "typed" tests almost exclusively, where each test case is instantiated several times, each time with a different tested type (here, 25 types). Building and running the tests was done without parallelism to simplify the comparison. The benchmarks were ran on a desktop with the following specs:
 
  - OS: Linux Mint 20.3, linux kernel 5.15.0-48-generic
  - CPU: AMD Ryzen 5 2600 (6 core)
  - RAM: 16GB
  - Storage: NVMe
- - Compiler: GCC 10.3.0
+ - Compiler: GCC 10.3.0 with `-std=c++20`
+ - snatch v0.1.2
+ - Catch2 0de60d8e7ead1ddd5ba8c46b901c122eac20bf94 (Sept. 14 2022)
+ - doctest 86892fc480f80fb57d9a3926cb506c0e974489d8 (Sept. 22 2022)
 
 Results:
 
-|                 | _Catch2_ (Debug) | _Catch2_ (Release) | _snatch_ (Debug) | _snatch_ (Release) |
-|-----------------|------------------|--------------------|------------------|--------------------|
-| Build framework | 41s              | 48s                | 1.0s             | 1.2s               |
-| Build tests     | 86s              | 310s               | 70s              | 149s               |
-| Build all       | 127s             | 358s               | 71s              | 150s               |
-| Run tests       | 74ms             | 36ms               | 15ms             | 7ms                |
-| Library size    | 34.6MB           | 2.5MB              | 0.51MB           | 0.05MB             |
-| Executable size | 51.5MB           | 19.1MB             | 31.0MB           | 9.3MB              |
+|                 | _Catch2_ (Debug) | _Catch2_ (Release) | _doctest_ (Debug) | _doctest_ (Release) | _snatch_ (Debug) | _snatch_ (Release) |
+|-----------------|------------------|--------------------|-------------------|---------------------|------------------|--------------------|
+| Build framework | 41s              | 48s                | 2.4s              | 4.1s                | 1.0s             | 1.2s               |
+| Build tests     | 86s              | 310s               | 76s               | 208s                | 70s              | 149s               |
+| Build all       | 127s             | 358s               | 78s               | 212s                | 71s              | 150s               |
+| Run tests       | 74ms             | 36ms               | 59ms              | 35ms                | 15ms             | 7ms                |
+| Library size    | 34.6MB           | 2.5MB              | 2.8MB             | 0.39MB              | 0.51MB           | 0.05MB             |
+| Executable size | 51.5MB           | 19.1MB             | 38.6MB            | 15.2MB              | 31.0MB           | 9.3MB              |
 
 
 ## Documentation

--- a/cmake/Findsnatch.cmake
+++ b/cmake/Findsnatch.cmake
@@ -1,0 +1,28 @@
+find_path(SNATCH_INCLUDE_DIR snatch.hpp
+  HINTS ${SNATCH_DIR}
+  PATH_SUFFIXES snatch include/snatch
+)
+
+find_library(SNATCH_LIBRARY
+    NAMES snatch snatch.lib
+    HINTS ${SNATCH_DIR}
+    PATH_SUFFIXES lib
+)
+
+set(SNATCH_INCLUDE_DIRS ${SNATCH_INCLUDE_DIR})
+set(SNATCH_LIBRARIES ${SNATCH_LIBRARY})
+
+include(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(snatch REQUIRED_VARS SNATCH_INCLUDE_DIRS SNATCH_LIBRARIES)
+
+mark_as_advanced(SNATCH_INCLUDE_DIR SNATCH_LIBRARY)
+
+if (SNATCH_FOUND)
+    if(NOT TARGET snatch::snatch)
+        add_library(snatch::snatch UNKNOWN IMPORTED)
+        set_target_properties(snatch::snatch PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${SNATCH_INCLUDE_DIRS}")
+        set_target_properties(snatch::snatch PROPERTIES INTERFACE_LINK_LIBRARIES "${SNATCH_LIBRARIES}")
+        set_target_properties(snatch::snatch PROPERTIES IMPORTED_LOCATION "${SNATCH_LIBRARY}")
+    endif()
+endif()

--- a/cmake/snatch-config.cmake.in
+++ b/cmake/snatch-config.cmake.in
@@ -1,0 +1,7 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/snatch-targets.cmake")
+
+if (NOT TARGET snatch::snatch)
+    add_library(snatch::snatch ALIAS snatch)
+endif ()

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -8,9 +8,6 @@
 #if !defined(SNATCH_DEFINE_MAIN)
 #    define SNATCH_DEFINE_MAIN 1
 #endif
-#if !defined(SNATCH_WITH_CXXOPTS)
-#    define SNATCH_WITH_CXXOPTS 0
-#endif
 
 // Testing framework implementation utilities.
 // -------------------------------------------


### PR DESCRIPTION
This PR does:
 - Add CMake install script to create the `.config` file.
 - Add a `Findsnatch.cmake` module.
 - Update benchmarks to include _doctest_.
 - Remove a leftover reference to cxxopts.