### PR TITLE
Add support for custom reporters and disabling colors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,13 @@ project(snatch LANGUAGES CXX VERSION 1.0)
 
 set(SNATCH_MAX_TEST_CASES         5000 CACHE STRING "Maximum number of test cases in a test application.")
 set(SNATCH_MAX_EXPR_LENGTH        1024 CACHE STRING "Maximum length of a printed expression when reporting failure.")
-set(SNATCH_MAX_MATCHER_MSG_LENGTH 1024 CACHE STRING "Maximum length of matcher error message when reporting failure.")
+set(SNATCH_MAX_MESSAGE_LENGTH     1024 CACHE STRING "Maximum length of error or status messages.")
 set(SNATCH_MAX_TEST_NAME_LENGTH   1024 CACHE STRING "Maximum length of a test case name.")
 set(SNATCH_MAX_UNIQUE_TAGS        1024 CACHE STRING "Maximum number of unique tags in a test application.")
 set(SNATCH_DEFINE_MAIN            ON   CACHE BOOL   "Define main() in snatch -- disable to provide your own main() function.")
 set(SNATCH_WITH_EXCEPTIONS        ON   CACHE BOOL   "Use exceptions in snatch implementation -- will be force OFF if exceptions are not available.")
 set(SNATCH_WITH_SHORTHAND_MACROS  ON   CACHE BOOL   "Use short names for test macros -- disable if this causes conflicts.")
+set(SNATCH_DEFAULT_WITH_COLOR     ON   CACHE BOOL   "Enable terminal colors by default -- can also be controlled on command line.")
 
 add_library(snatch ${PROJECT_SOURCE_DIR}/src/snatch.cpp)
 
@@ -23,12 +24,13 @@ target_include_directories(snatch PUBLIC
 target_compile_definitions(snatch PUBLIC
   SNATCH_MAX_TEST_CASES=${SNATCH_MAX_TEST_CASES}
   SNATCH_MAX_EXPR_LENGTH=${SNATCH_MAX_EXPR_LENGTH}
-  SNATCH_MAX_MATCHER_MSG_LENGTH=${SNATCH_MAX_MATCHER_MSG_LENGTH}
+  SNATCH_MAX_MESSAGE_LENGTH=${SNATCH_MAX_MESSAGE_LENGTH}
   SNATCH_MAX_TEST_NAME_LENGTH=${SNATCH_MAX_TEST_NAME_LENGTH}
   SNATCH_MAX_UNIQUE_TAGS=${SNATCH_MAX_UNIQUE_TAGS}
   SNATCH_DEFINE_MAIN=$<BOOL:${SNATCH_DEFINE_MAIN}>
   SNATCH_WITH_EXCEPTIONS=$<BOOL:${SNATCH_WITH_EXCEPTIONS}>
-  SNATCH_WITH_SHORTHAND_MACROS=$<BOOL:${SNATCH_WITH_SHORTHAND_MACROS}>)
+  SNATCH_WITH_SHORTHAND_MACROS=$<BOOL:${SNATCH_WITH_SHORTHAND_MACROS}>
+  SNATCH_DEFAULT_WITH_COLOR=$<BOOL:${SNATCH_DEFAULT_WITH_COLOR}>)
 
 install(FILES ${PROJECT_SOURCE_DIR}/include/snatch/snatch.hpp
   DESTINATION ${CMAKE_INSTALL_PREFIX}/include/snatch)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SNATCH_MAX_EXPR_LENGTH        1024 CACHE STRING "Maximum length of a printed
 set(SNATCH_MAX_MESSAGE_LENGTH     1024 CACHE STRING "Maximum length of error or status messages.")
 set(SNATCH_MAX_TEST_NAME_LENGTH   1024 CACHE STRING "Maximum length of a test case name.")
 set(SNATCH_MAX_UNIQUE_TAGS        1024 CACHE STRING "Maximum number of unique tags in a test application.")
+set(SNATCH_MAX_COMMAND_LINE_ARGS  1024 CACHE STRING "Maximum number of command line arguments to a test application.")
 set(SNATCH_DEFINE_MAIN            ON   CACHE BOOL   "Define main() in snatch -- disable to provide your own main() function.")
 set(SNATCH_WITH_EXCEPTIONS        ON   CACHE BOOL   "Use exceptions in snatch implementation -- will be force OFF if exceptions are not available.")
 set(SNATCH_WITH_SHORTHAND_MACROS  ON   CACHE BOOL   "Use short names for test macros -- disable if this causes conflicts.")
@@ -27,6 +28,7 @@ target_compile_definitions(snatch PUBLIC
   SNATCH_MAX_MESSAGE_LENGTH=${SNATCH_MAX_MESSAGE_LENGTH}
   SNATCH_MAX_TEST_NAME_LENGTH=${SNATCH_MAX_TEST_NAME_LENGTH}
   SNATCH_MAX_UNIQUE_TAGS=${SNATCH_MAX_UNIQUE_TAGS}
+  SNATCH_MAX_COMMAND_LINE_ARGS=${SNATCH_MAX_COMMAND_LINE_ARGS}
   SNATCH_DEFINE_MAIN=$<BOOL:${SNATCH_DEFINE_MAIN}>
   SNATCH_WITH_EXCEPTIONS=$<BOOL:${SNATCH_WITH_EXCEPTIONS}>
   SNATCH_WITH_SHORTHAND_MACROS=$<BOOL:${SNATCH_WITH_SHORTHAND_MACROS}>

--- a/README.md
+++ b/README.md
@@ -113,12 +113,12 @@ Results for _snatch_:
 
 |                 | _snatch_ (Debug) | _snatch_ (Release) |
 |-----------------|------------------|--------------------|
-| Build framework | 1.0s             | 1.2s               |
-| Build tests     | 70s              | 149s               |
-| Build all       | 71s              | 150s               |
-| Run tests       | 15ms             | 7ms                |
-| Library size    | 0.51MB           | 0.05MB             |
-| Executable size | 31.0MB           | 9.3MB              |
+| Build framework | 1.5s             | 2.2s               |
+| Build tests     | 65s              | 133s               |
+| Build all       | 67s              | 135s               |
+| Run tests       | 13ms             | 7ms                |
+| Library size    | 2.50MB           | 0.63MB             |
+| Executable size | 28.9MB           | 8.5MB              |
 
 Results for alternative testing frameworks:
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The goal of _snatch_ is to be a simple, cheap, non-invasive, and user-friendly t
 
 ## Features and limitations
 
- - No heap allocation from the testing framework.
+ - No heap allocation from the testing framework, so memory leaks from your code can be detected precisely.
  - Works with exceptions disabled, albeit with a minor limitation (see [Exceptions](#exceptions) below).
  - No external dependency; just pure C++20 with the STL.
  - Simple reporting of test results to the standard output, with coloring for readability.

--- a/README.md
+++ b/README.md
@@ -90,26 +90,49 @@ Output:
 
 The following benchmarks were done using real-world tests from another library ([observable_unique_ptr](https://github.com/cschreib/observable_unique_ptr)), which generates about 4000 test cases and 25000 checks. This library uses "typed" tests almost exclusively, where each test case is instantiated several times, each time with a different tested type (here, 25 types). Building and running the tests was done without parallelism to simplify the comparison. The benchmarks were ran on a desktop with the following specs:
 
- - OS: Linux Mint 20.3, linux kernel 5.15.0-48-generic
- - CPU: AMD Ryzen 5 2600 (6 core)
- - RAM: 16GB
- - Storage: NVMe
- - Compiler: GCC 10.3.0 with `-std=c++20`
- - snatch v0.1.2
- - Catch2 0de60d8e7ead1ddd5ba8c46b901c122eac20bf94 (Sept. 14 2022)
- - doctest 86892fc480f80fb57d9a3926cb506c0e974489d8 (Sept. 22 2022)
+ - OS: Linux Mint 20.3, linux kernel 5.15.0-48-generic.
+ - CPU: AMD Ryzen 5 2600 (6 core).
+ - RAM: 16GB.
+ - Storage: NVMe.
+ - Compiler: GCC 10.3.0 with `-std=c++20`.
+ - snatch v0.1.2.
+ - Catch2 0de60d8e7ead1ddd5ba8c46b901c122eac20bf94 (Sept. 14 2022).
+ - doctest 86892fc480f80fb57d9a3926cb506c0e974489d8 (Sept. 22 2022).
+ - Boost.UT cd12498349362cc646a7140451bf51db2a2dac00 (Feb. 1 2022), with modifications (see notes below).
 
-Results:
+Description of results below:
+ - *Build framework*: Time required to build the testing framework library (if any), without any test.
+ - *Build tests*: Time required to build the tests, assuming the framework library was already built (if any).
+ - *Build all*: Total time to build the tests and the framework library (if any).
+ - *Run tests*: Total time require to run the tests.
+ - *Library size*: Size of the compiled testing framework library (if any).
+ - *Executable size*: Size of the compiled test executable, static linking to the testing framework library (if any).
 
-|                 | _Catch2_ (Debug) | _Catch2_ (Release) | _doctest_ (Debug) | _doctest_ (Release) | _snatch_ (Debug) | _snatch_ (Release) |
-|-----------------|------------------|--------------------|-------------------|---------------------|------------------|--------------------|
-| Build framework | 41s              | 48s                | 2.4s              | 4.1s                | 1.0s             | 1.2s               |
-| Build tests     | 86s              | 310s               | 76s               | 208s                | 70s              | 149s               |
-| Build all       | 127s             | 358s               | 78s               | 212s                | 71s              | 150s               |
-| Run tests       | 74ms             | 36ms               | 59ms              | 35ms                | 15ms             | 7ms                |
-| Library size    | 34.6MB           | 2.5MB              | 2.8MB             | 0.39MB              | 0.51MB           | 0.05MB             |
-| Executable size | 51.5MB           | 19.1MB             | 38.6MB            | 15.2MB              | 31.0MB           | 9.3MB              |
+Results for _snatch_:
 
+|                 | _snatch_ (Debug) | _snatch_ (Release) |
+|-----------------|------------------|--------------------|
+| Build framework | 1.0s             | 1.2s               |
+| Build tests     | 70s              | 149s               |
+| Build all       | 71s              | 150s               |
+| Run tests       | 15ms             | 7ms                |
+| Library size    | 0.51MB           | 0.05MB             |
+| Executable size | 31.0MB           | 9.3MB              |
+
+Results for alternative testing frameworks:
+
+|                 | _Catch2_ (Debug) | _Catch2_ (Release) | _doctest_ (Debug) | _doctest_ (Release) | _Boost UT_ (Debug) | _Boost UT_ (Release) |
+|-----------------|------------------|--------------------|-------------------|---------------------|--------------------|----------------------|
+| Build framework | 41s              | 48s                | 2.4s              | 4.1s                | 0s                 | 0s                   |
+| Build tests     | 86s              | 310s               | 76s               | 208s                | 113s               | 279s                 |
+| Build all       | 127s             | 358s               | 78s               | 212s                | 113s               | 279s                 |
+| Run tests       | 74ms             | 36ms               | 59ms              | 35ms                | 20ms               | 10ms                 |
+| Library size    | 34.6MB           | 2.5MB              | 2.8MB             | 0.39MB              | 0MB                | 0MB                  |
+| Executable size | 51.5MB           | 19.1MB             | 38.6MB            | 15.2MB              | 51.7MB             | 11.3MB               |
+
+Notes:
+ - No attempt was made to optimize each framework's configuration; the defaults were used. C++20 modules were not used.
+ - _Boost UT_ was unable to compile and pass the tests without modifications to its implementation (issues were reported).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -231,8 +231,8 @@ void report_function(const snatch::registry& r, const snatch::event::data& e) no
 
 snatch::tests.report_callback = &report_function;
 
-// Lambda.
-// -------
+// Stateless lambda (no captures).
+// -------------------------------
 snatch::tests.report_callback = [](const snatch::registry& r, const snatch::event::data& e) noexcept {
     /* ... */
 };
@@ -292,14 +292,14 @@ int main(int argc, char* argv[]) {
     // Configure snatch using command line options.
     // You can then override the configuration below, or just remove this call to disable
     // command line options entirely.
-    snatch::tests.configure_from_command_line(*args);
+    snatch::tests.configure(*args);
 
     // Your own initialization code goes here.
     // ...
 
     // Actually run the tests.
     // This will apply any filtering specified on the command line.
-    return snatch::tests.run_tests_from_command_line(*args) ? 0 : 1;
+    return snatch::tests.run_tests(*args) ? 0 : 1;
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -217,10 +217,11 @@ The default `main()` function provided in _snatch_ offers the following command-
  - positional argument for filtering tests by name.
  - `-h,--help`: show command line help.
  - `-l,--list-tests`: list all tests.
- - `--list-tags`: list all tags.
- - `--verbose`: turn on verbose mode.
- - `--list-tests-with-tag`: list all tests with a given tag.
- - `--tags`: filter tests by tags instead of by name.
+ - `   --list-tags`: list all tags.
+ - `   --list-tests-with-tag`: list all tests with a given tag.
+ - `-t,--tags`: filter tests by tags instead of by name.
+ - `-v,--verbosity [quiet|normal|high]`: select level of detail for the default reporter.
+ - `   --color [always|never]`: enable/disable colors in the default reporter.
 
 
 ### Using your own main function
@@ -231,13 +232,31 @@ By default _snatch_ defines `main()` for you. To prevent this and provide your o
 set(SNATCH_DEFINE_MAIN OFF)
 ```
 
-just before calling `FetchContent_Declare()`. Then, in your own main function, call
+just before calling `FetchContent_Declare()`.
+
+Here is a recommended `main()` function that replicates the default behavior of snatch:
 
 ```c++
-bool success = snatch::tests.run_all_tests();
-```
+int main(int argc, char* argv[]) {
+    // Parse the command line arguments.
+    std::optional<snatch::cli::input> args = snatch::cli::parse_arguments(argc, argv);
+    if (!args) {
+        // Parsing failed, an error has been reported, just return.
+        return 1;
+    }
 
-or any other method from the `snatch::registry` class. `snatch::tests` is a global registry, which owns all registered test cases.
+    // Configure snatch using command line options.
+    // You can then override the configuration below, or just remove this call to disable
+    // command line options entirely.
+    snatch::tests.configure_from_command_line(*args);
+
+    // Your own initialization code goes here.
+    // ...
+
+    // Actually run the tests.
+    // This will apply any filtering specified on the command line.
+    return snatch::tests.run_tests_from_command_line(*args) ? 0 : 1;
+```
 
 
 ### Exceptions

--- a/README.md
+++ b/README.md
@@ -25,17 +25,17 @@ The goal of _snatch_ is to be a simple, cheap, non-invasive, and user-friendly t
  - No heap allocation from the testing framework, so memory leaks from your code can be detected precisely.
  - Works with exceptions disabled, albeit with a minor limitation (see [Exceptions](#exceptions) below).
  - No external dependency; just pure C++20 with the STL.
- - Simple reporting of test results to the standard output, with coloring for readability.
- - Test events can also be forwarded to a reporter callback, to support custom test reporting for CI frameworks (Teamcity, ...).
+ - Compiles tests at least 40% faster than other testing frameworks (see [Benchmark](#benchmark)).
+ - Defaults to reporting test results to the standard output, with coloring for readability, but test events can also be forwarded to a reporter callback for reporting to CI frameworks (Teamcity, ..., see [Reporters](#reporters)).
  - Limited subset of the [_Catch2_](https://github.com/catchorg/_Catch2_) API, including:
    - Simple test cases with `TEST_CASE(name, tags)`.
    - Typed test cases with `TEMPLATE_LIST_TEST_CASE(name, tags, types)`.
    - Pretty-printing check macros: `REQUIRE(expr)`, `CHECK(expr)`, `FAIL(msg)`, `FAIL_CHECK(msg)`.
    - Exception checking macros: `REQUIRE_THROWS_AS(expr, except)`, `CHECK_THROWS_AS(expr, except)`, `REQUIRE_THROWS_MATCHES(expr, exception, matcher)`, `CHECK_THROWS_MATCHES(expr, except, matcher)`.
    - Optional `main()` with simple command-line API similar to _Catch2_.
-   - Additional API not in _Catch2_, or different from _Catch2_:
-     - Macro to mark a test as skipped: `SKIP(msg)`.
-     - Matchers use a different API (see [Matchers](#matchers) below).
+ - Additional API not in _Catch2_, or different from _Catch2_:
+   - Macro to mark a test as skipped: `SKIP(msg)`.
+   - Matchers use a different API (see [Matchers](#matchers) below).
 
 If you need features that are not in the list above, please use _Catch2_ or _doctest_.
 
@@ -44,6 +44,7 @@ Notable current limitations:
  - Test macros (`REQUIRE(...)`, etc.) may only be used inside the test body (or in lambdas defined in the test body), and cannot be used in other functions.
  - No set-up/tear-down helpers.
  - No multi-threaded test execution.
+ - No `SECTION(...)`.
 
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -220,6 +220,40 @@ The callback is a single `noexcept` function, taking two arguments:
  - a reference to the `snatch::registry` that generated the event
  - a reference to the `snatch::event::data` containing the event data. This type is a `std::variant`; use `std::visit` to act on the event.
 
+The callback can be registered either as a free function, a stateless lambda, or a member function. You can register your own callback as follows:
+
+```c++
+// Free function.
+// --------------
+void report_function(const snatch::registry& r, const snatch::event::data& e) noexcept {
+    /* ... */
+}
+
+snatch::tests.report_callback = &report_function;
+
+// Lambda.
+// -------
+snatch::tests.report_callback = [](const snatch::registry& r, const snatch::event::data& e) noexcept {
+    /* ... */
+};
+
+// Member function (const or non-const, up to you).
+// ------------------------------------------------
+struct Reporter {
+    void report(const snatch::registry& r, const snatch::event::data& e) /*const*/ noexcept {
+        /* ... */
+    }
+};
+
+Reporter reporter; // must remain alive for the duration of the tests!
+
+snatch::tests.report_callback = {reporter, snatch::constant<&Reporter::report>};
+```
+
+If you need to use a reporter member function, please make sure that the reporter object remains alive for the duration of the tests (e.g., declare it static, global, or as a local variable declared in `main()`), or make sure to de-register it when your reporter is destroyed.
+
+An example reporter for _Teamcity_ is included for demonstration, see `include/snatch/snatch_teamcity.hpp`.
+
 
 ### Default main function
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The goal of _snatch_ is to be a simple, cheap, non-invasive, and user-friendly t
     - [Test case macros](#test-case-macros)
     - [Test check macros](#test-check-macros)
     - [Matchers](#matchers)
+    - [Reporters](#reporters)
     - [Default main function](#default-main-function)
     - [Using your own main function](#using-your-own-main-function)
     - [Exceptions](#exceptions)
@@ -25,6 +26,7 @@ The goal of _snatch_ is to be a simple, cheap, non-invasive, and user-friendly t
  - Works with exceptions disabled, albeit with a minor limitation (see [Exceptions](#exceptions) below).
  - No external dependency; just pure C++20 with the STL.
  - Simple reporting of test results to the standard output, with coloring for readability.
+ - Test events can also be forwarded to a reporter callback, to support custom test reporting for CI frameworks (Teamcity, ...).
  - Limited subset of the [_Catch2_](https://github.com/catchorg/_Catch2_) API, including:
    - Simple test cases with `TEST_CASE(name, tags)`.
    - Typed test cases with `TEMPLATE_LIST_TEST_CASE(name, tags, types)`.
@@ -41,7 +43,6 @@ Notable current limitations:
 
  - Test macros (`REQUIRE(...)`, etc.) may only be used inside the test body (or in lambdas defined in the test body), and cannot be used in other functions.
  - No set-up/tear-down helpers.
- - Only reports to the standard output; no custom reporter.
  - No multi-threaded test execution.
 
 
@@ -209,6 +210,15 @@ Two matchers are provided with _snatch_:
 
  - `snatch::matchers::contains_substring{"substring"}`: accepts a `std::string_view`, and will return a match if the string contains `"substring"`.
  - `snatch::matchers::with_what_contains{"substring"}`: accepts a `std::exception`, and will return a match if `what()` contains `"substring"`.
+
+
+### Reporters
+
+By default, _snatch_ will report the test results to the standard output, using its own report format. You can override this by supplying your own "reporter" callback function to the test registry. This requires [using your own main function](#using-your-own-main-function).
+
+The callback is a single `noexcept` function, taking two arguments:
+ - a reference to the `snatch::registry` that generated the event
+ - a reference to the `snatch::event::data` containing the event data. This type is a `std::variant`; use `std::visit` to act on the event.
 
 
 ### Default main function

--- a/README.md
+++ b/README.md
@@ -205,6 +205,12 @@ Matchers in _snatch_ work differently than in _Catch2_. The required interface i
  - `matcher.describe_fail(obj)` must return a `std::string_view` describing why `obj` is not a match. The lifetime of the string referenced by the string view must be equal or greater than the lifetime of the matcher (e.g., the string view can point to a temporary buffer stored inside the matcher).
 
 
+Two matchers are provided with _snatch_:
+
+ - `snatch::matchers::contains_substring{"substring"}`: accepts a `std::string_view`, and will return a match if the string contains `"substring"`.
+ - `snatch::matchers::with_what_contains{"substring"}`: accepts a `std::exception`, and will return a match if `what()` contains `"substring"`.
+
+
 ### Default main function
 
 The default `main()` function provided in _snatch_ offers the following command-line API:

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -631,7 +631,7 @@ struct expression {
 #undef EXPR_OPERATOR
 };
 
-void stddout_print(std::string_view message) noexcept;
+void stdout_print(std::string_view message) noexcept;
 
 struct abort_exception {};
 } // namespace snatch::impl
@@ -724,7 +724,7 @@ public:
     using print_function  = small_function<void(std::string_view) noexcept>;
     using report_function = small_function<void(const registry&, const event::data&) noexcept>;
 
-    print_function  print_callback = &snatch::impl::stddout_print;
+    print_function  print_callback = &snatch::impl::stdout_print;
     report_function report_callback;
 
     template<typename... Args>

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -465,6 +465,7 @@ template<typename T, typename U, typename... Args>
 void truncate_end(small_string_span ss) noexcept;
 
 struct expression {
+    std::string_view              content;
     small_string<max_expr_length> data;
     bool                          failed = false;
 
@@ -574,10 +575,7 @@ public:
     void print_failure() const noexcept;
     void print_skip() const noexcept;
     void print_details(std::string_view message) const noexcept;
-    void print_details_expr(
-        std::string_view        check,
-        std::string_view        exp_str,
-        const impl::expression& exp) const noexcept;
+    void print_details_expr(const impl::expression& exp) const noexcept;
 
     void run(impl::test_case& t) noexcept;
     void set_state(impl::test_case& t, impl::test_state s) noexcept;
@@ -685,7 +683,7 @@ struct with_what_contains : private contains_substring {
 
 #define SNATCH_CONCAT_IMPL(x, y) x##y
 #define SNATCH_MACRO_CONCAT(x, y) SNATCH_CONCAT_IMPL(x, y)
-#define SNATCH_EXPR(x) snatch::impl::expression{} <= x
+#define SNATCH_EXPR(type, x) snatch::impl::expression{type "(" #x ")", {}, false} <= x
 
 #define SNATCH_TEST_CASE(NAME, TAGS)                                                               \
     static const char* SNATCH_MACRO_CONCAT(test_id_, __COUNTER__) =                                \
@@ -704,10 +702,9 @@ struct with_what_contains : private contains_substring {
         SNATCH_WARNING_DISABLE_PARENTHESES;                                                        \
         SNATCH_WARNING_DISABLE_CONSTANT_COMPARISON;                                                \
         if (!(EXP)) {                                                                              \
-            const auto EXP2 = SNATCH_EXPR(EXP);                                                    \
             snatch::tests.print_failure();                                                         \
             snatch::tests.print_location(CURRENT_CASE, __FILE__, __LINE__);                        \
-            snatch::tests.print_details_expr("REQUIRE", #EXP, EXP2);                               \
+            snatch::tests.print_details_expr(SNATCH_EXPR("REQUIRE", EXP));                         \
             SNATCH_TESTING_ABORT(CURRENT_CASE, snatch::impl::test_state::failed);                  \
         }                                                                                          \
         SNATCH_WARNING_POP;                                                                        \
@@ -720,10 +717,9 @@ struct with_what_contains : private contains_substring {
         SNATCH_WARNING_DISABLE_PARENTHESES;                                                        \
         SNATCH_WARNING_DISABLE_CONSTANT_COMPARISON;                                                \
         if (!(EXP)) {                                                                              \
-            const auto EXP2 = SNATCH_EXPR(EXP);                                                    \
             snatch::tests.print_failure();                                                         \
             snatch::tests.print_location(CURRENT_CASE, __FILE__, __LINE__);                        \
-            snatch::tests.print_details_expr("CHECK", #EXP, EXP2);                                 \
+            snatch::tests.print_details_expr(SNATCH_EXPR("CHECK", EXP));                           \
             snatch::tests.set_state(CURRENT_CASE, snatch::impl::test_state::failed);               \
         }                                                                                          \
         SNATCH_WARNING_POP;                                                                        \

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -624,7 +624,7 @@ public:
     bool with_color                                      = true;
 
     using print_function  = void (*)(std::string_view) noexcept;
-    using report_function = void (*)(const event::data&) noexcept;
+    using report_function = void (*)(const registry&, const event::data&) noexcept;
 
     print_function  print_callback  = &snatch::impl::stddout_print;
     report_function report_callback = nullptr;

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -142,9 +142,10 @@ enum class test_state { not_run, success, skipped, failed };
 
 struct test_case {
     test_id     id;
-    test_ptr    func    = nullptr;
-    test_state  state   = test_state::not_run;
-    std::size_t asserts = 0;
+    test_ptr    func     = nullptr;
+    test_state  state    = test_state::not_run;
+    std::size_t asserts  = 0;
+    float       duration = 0.0f;
 };
 } // namespace snatch::impl
 
@@ -660,6 +661,7 @@ struct test_case_started {
 
 struct test_case_ended {
     const test_id& id;
+    float          duration = 0.0f;
 };
 
 struct assertion_failed {

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -510,7 +510,7 @@ struct expression {
 #undef EXPR_OPERATOR
 };
 
-void default_print(std::string_view message) noexcept;
+void stddout_print(std::string_view message) noexcept;
 } // namespace snatch::impl
 
 // Utilities.
@@ -544,7 +544,7 @@ public:
 
     using print_function = void (*)(std::string_view) noexcept;
 
-    print_function print_callback = &snatch::impl::default_print;
+    print_function print_callback = &snatch::impl::stddout_print;
 
     impl::proxy<std::tuple<>> add(std::string_view name, std::string_view tags) noexcept {
         return {this, name, tags};

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -528,6 +528,14 @@ namespace snatch {
 class registry {
     impl::small_vector<impl::test_case, max_test_cases> test_list;
 
+public:
+    enum class verbosity { quiet, normal, high } verbose = verbosity::normal;
+    bool with_color                                      = true;
+
+    using print_function = void (*)(std::string_view) noexcept;
+
+    print_function print_callback = &snatch::impl::stddout_print;
+
     template<typename... Args>
     void print(Args&&... args) const noexcept {
         snatch::impl::small_string<max_message_length> message;
@@ -537,14 +545,6 @@ class registry {
 
         (*this->print_callback)(message);
     }
-
-public:
-    enum class verbosity { quiet, normal, high } verbose = verbosity::normal;
-    bool with_color                                      = true;
-
-    using print_function = void (*)(std::string_view) noexcept;
-
-    print_function print_callback = &snatch::impl::stddout_print;
 
     impl::proxy<std::tuple<>> add(std::string_view name, std::string_view tags) noexcept {
         return {this, name, tags};

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -783,8 +783,9 @@ public:
     bool run_tests_matching_name(std::string_view run_name, std::string_view name_filter) noexcept;
     bool run_tests_with_tag(std::string_view run_name, std::string_view tag_filter) noexcept;
 
-    void configure_from_command_line(const cli::input& args) noexcept;
-    bool run_tests_from_command_line(const cli::input& args) noexcept;
+    bool run_tests(const cli::input& args) noexcept;
+
+    void configure(const cli::input& args) noexcept;
 
     void list_all_tests() const noexcept;
     void list_all_tags() const noexcept;

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -609,7 +609,7 @@ const char* proxy<std::tuple<Args...>>::operator=(const F& func) noexcept {
     if constexpr (sizeof...(Args) > 0) {
         tests->template register_type_tests<Args...>(name, tags, func);
     } else {
-        tests->register_test(name, tags, {}, func);
+        tests->register_test({name, tags, {}}, func);
     }
     return name.data();
 }

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -525,8 +525,8 @@ class registry {
     impl::small_vector<impl::test_case, max_test_cases> test_list;
 
 public:
-    bool verbose    = false;
-    bool with_color = true;
+    enum class verbosity { quiet, normal, high } verbose = verbosity::normal;
+    bool with_color                                      = true;
 
     impl::proxy<std::tuple<>> add(std::string_view name, std::string_view tags) noexcept {
         return {this, name, tags};

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -749,7 +749,8 @@ public:
     void register_test(const test_id& id, impl::test_ptr func) noexcept;
 
     template<typename... Args, typename F>
-    void register_type_tests(std::string_view name, std::string_view tags, const F& func) noexcept {
+    void
+    register_typed_tests(std::string_view name, std::string_view tags, const F& func) noexcept {
         (register_test(
              {name, tags, impl::get_type_name<Args>()}, impl::to_test_case_ptr<Args>(func)),
          ...);
@@ -806,7 +807,7 @@ template<typename... Args>
 template<typename F>
 const char* proxy<std::tuple<Args...>>::operator=(const F& func) noexcept {
     if constexpr (sizeof...(Args) > 0) {
-        tests->template register_type_tests<Args...>(name, tags, func);
+        tests->template register_typed_tests<Args...>(name, tags, func);
     } else {
         tests->register_test({name, tags, {}}, func);
     }

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -72,7 +72,13 @@ constexpr std::size_t max_unique_tags = SNATCH_MAX_UNIQUE_TAGS;
 
 namespace snatch {
 class registry;
-}
+
+struct test_id {
+    std::string_view name;
+    std::string_view tags;
+    std::string_view type;
+};
+} // namespace snatch
 
 // Implementation details.
 // -----------------------
@@ -128,12 +134,10 @@ constexpr test_ptr to_test_case_ptr(const F&) noexcept {
 enum class test_state { not_run, success, skipped, failed };
 
 struct test_case {
-    std::string_view name;
-    std::string_view tags;
-    std::string_view type;
-    test_ptr         func    = nullptr;
-    test_state       state   = test_state::not_run;
-    std::size_t      asserts = 0;
+    test_id     id;
+    test_ptr    func    = nullptr;
+    test_state  state   = test_state::not_run;
+    std::size_t asserts = 0;
 };
 
 [[noreturn]] void terminate_with(std::string_view msg) noexcept;
@@ -555,15 +559,12 @@ public:
         return {this, name, tags};
     }
 
-    void register_test(
-        std::string_view name,
-        std::string_view tags,
-        std::string_view type,
-        impl::test_ptr   func) noexcept;
+    void register_test(const test_id& id, impl::test_ptr func) noexcept;
 
     template<typename... Args, typename F>
     void register_type_tests(std::string_view name, std::string_view tags, const F& func) noexcept {
-        (register_test(name, tags, impl::get_type_name<Args>(), impl::to_test_case_ptr<Args>(func)),
+        (register_test(
+             {name, tags, impl::get_type_name<Args>()}, impl::to_test_case_ptr<Args>(func)),
          ...);
     }
 

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -131,9 +131,9 @@ struct test_case {
     std::string_view name;
     std::string_view tags;
     std::string_view type;
-    test_ptr         func  = nullptr;
-    test_state       state = test_state::not_run;
-    std::size_t      tests = 0;
+    test_ptr         func    = nullptr;
+    test_state       state   = test_state::not_run;
+    std::size_t      asserts = 0;
 };
 
 [[noreturn]] void terminate_with(std::string_view msg) noexcept;
@@ -680,7 +680,7 @@ struct with_what_contains : private contains_substring {
 
 #define SNATCH_REQUIRE(EXP)                                                                        \
     do {                                                                                           \
-        ++CURRENT_CASE.tests;                                                                      \
+        ++CURRENT_CASE.asserts;                                                                    \
         SNATCH_WARNING_PUSH;                                                                       \
         SNATCH_WARNING_DISABLE_PARENTHESES;                                                        \
         SNATCH_WARNING_DISABLE_CONSTANT_COMPARISON;                                                \
@@ -696,7 +696,7 @@ struct with_what_contains : private contains_substring {
 
 #define SNATCH_CHECK(EXP)                                                                          \
     do {                                                                                           \
-        ++CURRENT_CASE.tests;                                                                      \
+        ++CURRENT_CASE.asserts;                                                                    \
         SNATCH_WARNING_PUSH;                                                                       \
         SNATCH_WARNING_DISABLE_PARENTHESES;                                                        \
         SNATCH_WARNING_DISABLE_CONSTANT_COMPARISON;                                                \

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -537,7 +537,7 @@ public:
     template<typename... CArgs>
     constexpr Ret operator()(CArgs&&... args) const noexcept {
         return std::visit(
-            overload(
+            overload{
                 [](std::monostate) {},
                 [&](function_ptr f) { return (*f)(std::forward<CArgs>(args)...); },
                 [&](const function_and_data_ptr& f) {
@@ -545,7 +545,7 @@ public:
                 },
                 [&](const function_and_const_data_ptr& f) {
                     return (*f.ptr)(f.data, std::forward<CArgs>(args)...);
-                }),
+                }},
             data);
     }
 

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -693,11 +693,12 @@ public:
     enum class verbosity { quiet, normal, high } verbose = verbosity::normal;
     bool with_color                                      = true;
 
-    using print_function  = void (*)(std::string_view) noexcept;
-    using report_function = void (*)(const registry&, const event::data&) noexcept;
+    using print_function = impl::small_function<void(std::string_view) noexcept>;
+    using report_function =
+        impl::small_function<void(const registry&, const event::data&) noexcept>;
 
-    print_function  print_callback  = &snatch::impl::stddout_print;
-    report_function report_callback = nullptr;
+    print_function  print_callback = &snatch::impl::stddout_print;
+    report_function report_callback;
 
     template<typename... Args>
     void print(Args&&... args) const noexcept {
@@ -706,7 +707,7 @@ public:
             snatch::impl::truncate_end(message);
         }
 
-        (*this->print_callback)(message);
+        this->print_callback(message);
     }
 
     impl::proxy<std::tuple<>> add(std::string_view name, std::string_view tags) noexcept {

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -479,6 +479,11 @@ template<typename T, typename U, typename... Args>
 
 void truncate_end(small_string_span ss) noexcept;
 
+[[nodiscard]] bool replace_all(
+    impl::small_string_span string,
+    std::string_view        pattern,
+    std::string_view        replacement) noexcept;
+
 template<auto T>
 struct constant {
     static constexpr auto value = T;

--- a/include/snatch/snatch_teamcity.hpp
+++ b/include/snatch/snatch_teamcity.hpp
@@ -1,0 +1,100 @@
+#ifndef SNATCH_TEAMCITY_HPP
+#define SNATCH_TEAMCITY_HPP
+
+#include "snatch/snatch.hpp"
+
+namespace snatch::teamcity {
+struct key_value {
+    std::string_view key;
+    std::string_view value;
+};
+
+void escape(impl::small_string_span string) noexcept {
+    if (!replace_all(string, "|", "||") || !replace_all(string, "'", "|'") ||
+        !replace_all(string, "\n", "|n") || !replace_all(string, "\r", "|r") ||
+        !replace_all(string, "[", "|[") || !replace_all(string, "]", "|]")) {
+        truncate_end(string);
+    }
+}
+
+void send_message(
+    const registry& r, std::string_view message, std::initializer_list<key_value> args) noexcept {
+    constexpr std::string_view teamcity_header = "##teamCity[";
+    constexpr std::string_view teamcity_footer = "]\n";
+
+    r.print(teamcity_header, message);
+    for (const auto& arg : args) {
+        r.print(" ", arg.key, "='", arg.value, "'");
+    }
+    r.print(teamcity_footer);
+}
+
+impl::small_string<max_test_name_length> make_full_name(const test_id& id) noexcept {
+    impl::small_string<max_test_name_length> name;
+    if (id.type.length() != 0) {
+        if (!append(name, id.name, "(\"", id.type, "\")")) {
+            truncate_end(name);
+        }
+    } else {
+        if (!append(name, id.name)) {
+            truncate_end(name);
+        }
+    }
+
+    escape(name);
+    return name;
+}
+
+impl::small_string<max_message_length>
+make_full_message(const snatch::assertion_location& location, std::string_view message) noexcept {
+    impl::small_string<max_message_length> full_message;
+    if (!append(full_message, location.file, ":", location.line, "\n", message)) {
+        truncate_end(full_message);
+    }
+
+    escape(full_message);
+    return full_message;
+}
+
+impl::small_string<max_message_length> make_escaped(std::string_view string) noexcept {
+    impl::small_string<max_message_length> escaped_string;
+    if (!append(escaped_string, string)) {
+        truncate_end(escaped_string);
+    }
+
+    escape(escaped_string);
+    return escaped_string;
+}
+
+void report(const registry& r, const snatch::event::data& event) noexcept {
+    std::visit(
+        snatch::overload(
+            [&](const snatch::event::test_run_started& e) {
+                send_message(r, "testSuiteStarted", {{"name", make_escaped(e.name)}});
+            },
+            [&](const snatch::event::test_run_ended& e) {
+                send_message(r, "testSuiteFinished", {{"name", make_escaped(e.name)}});
+            },
+            [&](const snatch::event::test_case_started& e) {
+                send_message(r, "testStarted", {{"name", make_full_name(e.id)}});
+            },
+            [&](const snatch::event::test_case_ended& e) {
+                send_message(r, "testFinished", {{"name", make_full_name(e.id)}});
+            },
+            [&](const snatch::event::test_case_skipped& e) {
+                send_message(
+                    r, "testIgnored",
+                    {{"name", make_full_name(e.id)},
+                     {"message", make_full_message(e.location, e.message)}});
+            },
+            [&](const snatch::event::assertion_failed& e) {
+                send_message(
+                    r, "testFailed",
+                    {{"name", make_full_name(e.id)},
+                     {"message", make_full_message(e.location, e.message)}});
+            }),
+        event);
+}
+} // namespace snatch::teamcity
+
+#endif

--- a/include/snatch/snatch_teamcity.hpp
+++ b/include/snatch/snatch_teamcity.hpp
@@ -68,7 +68,7 @@ impl::small_string<max_message_length> make_escaped(std::string_view string) noe
 
 void report(const registry& r, const snatch::event::data& event) noexcept {
     std::visit(
-        snatch::overload(
+        snatch::overload{
             [&](const snatch::event::test_run_started& e) {
                 send_message(r, "testSuiteStarted", {{"name", make_escaped(e.name)}});
             },
@@ -92,7 +92,7 @@ void report(const registry& r, const snatch::event::data& event) noexcept {
                     r, "testFailed",
                     {{"name", make_full_name(e.id)},
                      {"message", make_full_message(e.location, e.message)}});
-            }),
+            }},
         event);
 }
 } // namespace snatch::teamcity

--- a/include/snatch/snatch_teamcity.hpp
+++ b/include/snatch/snatch_teamcity.hpp
@@ -9,7 +9,7 @@ struct key_value {
     std::string_view value;
 };
 
-void escape(impl::small_string_span string) noexcept {
+void escape(small_string_span string) noexcept {
     if (!replace_all(string, "|", "||") || !replace_all(string, "'", "|'") ||
         !replace_all(string, "\n", "|n") || !replace_all(string, "\r", "|r") ||
         !replace_all(string, "[", "|[") || !replace_all(string, "]", "|]")) {
@@ -29,8 +29,8 @@ void send_message(
     r.print(teamcity_footer);
 }
 
-impl::small_string<max_test_name_length> make_full_name(const test_id& id) noexcept {
-    impl::small_string<max_test_name_length> name;
+small_string<max_test_name_length> make_full_name(const test_id& id) noexcept {
+    small_string<max_test_name_length> name;
     if (id.type.length() != 0) {
         if (!append(name, id.name, "(\"", id.type, "\")")) {
             truncate_end(name);
@@ -45,9 +45,9 @@ impl::small_string<max_test_name_length> make_full_name(const test_id& id) noexc
     return name;
 }
 
-impl::small_string<max_message_length>
+small_string<max_message_length>
 make_full_message(const snatch::assertion_location& location, std::string_view message) noexcept {
-    impl::small_string<max_message_length> full_message;
+    small_string<max_message_length> full_message;
     if (!append(full_message, location.file, ":", location.line, "\n", message)) {
         truncate_end(full_message);
     }
@@ -56,8 +56,8 @@ make_full_message(const snatch::assertion_location& location, std::string_view m
     return full_message;
 }
 
-impl::small_string<max_message_length> make_escaped(std::string_view string) noexcept {
-    impl::small_string<max_message_length> escaped_string;
+small_string<max_message_length> make_escaped(std::string_view string) noexcept {
+    small_string<max_message_length> escaped_string;
     if (!append(escaped_string, string)) {
         truncate_end(escaped_string);
     }

--- a/include/snatch/snatch_teamcity.hpp
+++ b/include/snatch/snatch_teamcity.hpp
@@ -66,6 +66,15 @@ small_string<max_message_length> make_escaped(std::string_view string) noexcept 
     return escaped_string;
 }
 
+small_string<32> make_duration(float duration) noexcept {
+    small_string<32> string;
+    if (!append(string, static_cast<std::size_t>(duration * 1e6))) {
+        truncate_end(string);
+    }
+
+    return string;
+}
+
 void report(const registry& r, const snatch::event::data& event) noexcept {
     std::visit(
         snatch::overload{
@@ -79,7 +88,9 @@ void report(const registry& r, const snatch::event::data& event) noexcept {
                 send_message(r, "testStarted", {{"name", make_full_name(e.id)}});
             },
             [&](const snatch::event::test_case_ended& e) {
-                send_message(r, "testFinished", {{"name", make_full_name(e.id)}});
+                send_message(
+                    r, "testFinished",
+                    {{"name", make_full_name(e.id)}, {"duration", make_duration(e.duration)}});
             },
             [&](const snatch::event::test_case_skipped& e) {
                 send_message(

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -582,8 +582,6 @@ constinit registry tests = []() {
 }();
 } // namespace snatch
 
-#if SNATCH_DEFINE_MAIN
-
 // Main entry point utilities.
 // ---------------------------
 
@@ -941,6 +939,8 @@ bool registry::run_tests_from_command_line(const cli::input& args) noexcept {
     }
 }
 } // namespace snatch
+
+#if SNATCH_DEFINE_MAIN
 
 // Main entry point.
 // -----------------

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -15,17 +15,33 @@
 // Testing framework implementation utilities.
 // -------------------------------------------
 
-namespace { namespace color {
-constexpr const char* error [[maybe_unused]]      = "\x1b[1;31m";
-constexpr const char* warning [[maybe_unused]]    = "\x1b[1;33m";
-constexpr const char* status [[maybe_unused]]     = "\x1b[1;36m";
-constexpr const char* fail [[maybe_unused]]       = "\x1b[1;31m";
-constexpr const char* skipped [[maybe_unused]]    = "\x1b[1;33m";
-constexpr const char* pass [[maybe_unused]]       = "\x1b[1;32m";
-constexpr const char* highlight1 [[maybe_unused]] = "\x1b[1;35m";
-constexpr const char* highlight2 [[maybe_unused]] = "\x1b[1;36m";
-constexpr const char* reset [[maybe_unused]]      = "\x1b[0m";
-}} // namespace ::color
+namespace {
+using color_t = const char*;
+
+namespace color {
+constexpr color_t error [[maybe_unused]]      = "\x1b[1;31m";
+constexpr color_t warning [[maybe_unused]]    = "\x1b[1;33m";
+constexpr color_t status [[maybe_unused]]     = "\x1b[1;36m";
+constexpr color_t fail [[maybe_unused]]       = "\x1b[1;31m";
+constexpr color_t skipped [[maybe_unused]]    = "\x1b[1;33m";
+constexpr color_t pass [[maybe_unused]]       = "\x1b[1;32m";
+constexpr color_t highlight1 [[maybe_unused]] = "\x1b[1;35m";
+constexpr color_t highlight2 [[maybe_unused]] = "\x1b[1;36m";
+constexpr color_t reset [[maybe_unused]]      = "\x1b[0m";
+} // namespace color
+
+template<typename T>
+struct colored {
+    const T& value;
+    color_t  color_start;
+    color_t  color_end;
+};
+
+template<typename T>
+colored<T> make_colored(const T& t, bool with_color, color_t start) {
+    return {t, with_color ? start : "", with_color ? color::reset : ""};
+}
+} // namespace
 
 namespace {
 using snatch::impl::small_string_span;
@@ -105,7 +121,6 @@ bool append(small_string_span ss, double d) noexcept {
 bool append(small_string_span ss, bool value) noexcept {
     return append(ss, value ? "true" : "false");
 }
-
 } // namespace snatch::impl
 
 namespace {
@@ -120,20 +135,6 @@ void truncate_end(small_string_span ss) noexcept {
 
     ss.resize(final_length);
     std::memcpy(ss.begin() + offset, "...", num_dots);
-}
-
-using color_t = const char*;
-
-template<typename T>
-struct colored {
-    const T& value;
-    color_t  color_start;
-    color_t  color_end;
-};
-
-template<typename T>
-colored<T> make_colored(const T& t, bool with_color, color_t start) {
-    return {t, with_color ? start : "", with_color ? color::reset : ""};
 }
 
 template<typename T>

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -204,8 +204,8 @@ using namespace snatch::impl;
 
 template<typename F>
 bool run_tests(registry& r, std::string_view run_name, F&& predicate) noexcept {
-    if (r.report_callback != nullptr) {
-        (*r.report_callback)(r, event::test_run_started{run_name});
+    if (!r.report_callback.empty()) {
+        r.report_callback(r, event::test_run_started{run_name});
     }
 
     bool        success         = true;
@@ -231,8 +231,8 @@ bool run_tests(registry& r, std::string_view run_name, F&& predicate) noexcept {
         }
     }
 
-    if (r.report_callback != nullptr) {
-        (*r.report_callback)(r, event::test_run_ended{run_name});
+    if (!r.report_callback.empty()) {
+        r.report_callback(r, event::test_run_ended{run_name});
     } else if (is_at_least(r.verbose, registry::verbosity::normal)) {
         r.print("==========================================\n");
 
@@ -380,8 +380,8 @@ void registry::report_failure(
 
     set_state(t, test_state::failed);
 
-    if (report_callback != nullptr) {
-        (*report_callback)(*this, event::assertion_failed{t.id, location, message});
+    if (!report_callback.empty()) {
+        report_callback(*this, event::assertion_failed{t.id, location, message});
     } else {
         print_failure();
         print_location(t, location);
@@ -402,8 +402,8 @@ void registry::report_failure(
         truncate_end(message);
     }
 
-    if (report_callback != nullptr) {
-        (*report_callback)(*this, event::assertion_failed{t.id, location, message});
+    if (!report_callback.empty()) {
+        report_callback(*this, event::assertion_failed{t.id, location, message});
     } else {
         print_failure();
         print_location(t, location);
@@ -418,15 +418,15 @@ void registry::report_failure(
 
     set_state(t, test_state::failed);
 
-    if (report_callback != nullptr) {
+    if (!report_callback.empty()) {
         if (!exp.failed) {
             small_string<max_message_length> message;
             if (!append(message, exp.content, ", got ", exp.data)) {
                 truncate_end(message);
             }
-            (*report_callback)(*this, event::assertion_failed{t.id, location, message});
+            report_callback(*this, event::assertion_failed{t.id, location, message});
         } else {
-            (*report_callback)(*this, event::assertion_failed{t.id, location, {exp.content}});
+            report_callback(*this, event::assertion_failed{t.id, location, {exp.content}});
         }
     } else {
         print_failure();
@@ -442,8 +442,8 @@ void registry::report_skipped(
 
     set_state(t, test_state::skipped);
 
-    if (report_callback != nullptr) {
-        (*report_callback)(*this, event::test_case_skipped{t.id, location, message});
+    if (!report_callback.empty()) {
+        report_callback(*this, event::test_case_skipped{t.id, location, message});
     } else {
         print_skip();
         print_location(t, location);
@@ -454,8 +454,8 @@ void registry::report_skipped(
 void registry::run(test_case& t) noexcept {
     small_string<max_test_name_length> full_name;
 
-    if (report_callback != nullptr) {
-        (*report_callback)(*this, event::test_case_started{t.id});
+    if (!report_callback.empty()) {
+        report_callback(*this, event::test_case_started{t.id});
     } else if (is_at_least(verbose, verbosity::high)) {
         make_full_name(full_name, t.id);
         print(
@@ -481,8 +481,8 @@ void registry::run(test_case& t) noexcept {
     t.func(t);
 #endif
 
-    if (report_callback != nullptr) {
-        (*report_callback)(*this, event::test_case_ended{t.id});
+    if (!report_callback.empty()) {
+        report_callback(*this, event::test_case_ended{t.id});
     } else if (is_at_least(verbose, verbosity::high)) {
         print(
             make_colored("finished:", with_color, color::status), " ",

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -205,7 +205,7 @@ using namespace snatch::impl;
 template<typename F>
 bool run_tests(registry& r, std::string_view run_name, F&& predicate) noexcept {
     if (r.report_callback != nullptr) {
-        (*r.report_callback)(event::test_run_started{run_name});
+        (*r.report_callback)(r, event::test_run_started{run_name});
     }
 
     bool        success         = true;
@@ -232,7 +232,7 @@ bool run_tests(registry& r, std::string_view run_name, F&& predicate) noexcept {
     }
 
     if (r.report_callback != nullptr) {
-        (*r.report_callback)(event::test_run_ended{run_name});
+        (*r.report_callback)(r, event::test_run_ended{run_name});
     } else if (is_at_least(r.verbose, registry::verbosity::normal)) {
         r.print("==========================================\n");
 
@@ -381,7 +381,7 @@ void registry::report_failure(
     set_state(t, test_state::failed);
 
     if (report_callback != nullptr) {
-        (*report_callback)(event::assertion_failed{t.id, location, message});
+        (*report_callback)(*this, event::assertion_failed{t.id, location, message});
     } else {
         print_failure();
         print_location(t, location);
@@ -403,7 +403,7 @@ void registry::report_failure(
     }
 
     if (report_callback != nullptr) {
-        (*report_callback)(event::assertion_failed{t.id, location, message});
+        (*report_callback)(*this, event::assertion_failed{t.id, location, message});
     } else {
         print_failure();
         print_location(t, location);
@@ -424,9 +424,9 @@ void registry::report_failure(
             if (!append(message, exp.content, ", got ", exp.data)) {
                 truncate_end(message);
             }
-            (*report_callback)(event::assertion_failed{t.id, location, message});
+            (*report_callback)(*this, event::assertion_failed{t.id, location, message});
         } else {
-            (*report_callback)(event::assertion_failed{t.id, location, {exp.content}});
+            (*report_callback)(*this, event::assertion_failed{t.id, location, {exp.content}});
         }
     } else {
         print_failure();
@@ -443,7 +443,7 @@ void registry::report_skipped(
     set_state(t, test_state::skipped);
 
     if (report_callback != nullptr) {
-        (*report_callback)(event::test_case_skipped{t.id, location, message});
+        (*report_callback)(*this, event::test_case_skipped{t.id, location, message});
     } else {
         print_skip();
         print_location(t, location);
@@ -455,7 +455,7 @@ void registry::run(test_case& t) noexcept {
     small_string<max_test_name_length> full_name;
 
     if (report_callback != nullptr) {
-        (*report_callback)(event::test_case_started{t.id});
+        (*report_callback)(*this, event::test_case_started{t.id});
     } else if (is_at_least(verbose, verbosity::high)) {
         make_full_name(full_name, t.id);
         print(
@@ -482,7 +482,7 @@ void registry::run(test_case& t) noexcept {
 #endif
 
     if (report_callback != nullptr) {
-        (*report_callback)(event::test_case_ended{t.id});
+        (*report_callback)(*this, event::test_case_ended{t.id});
     } else if (is_at_least(verbose, verbosity::high)) {
         print(
             make_colored("finished:", with_color, color::status), " ",

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -350,15 +350,8 @@ void registry::print_details(std::string_view message) const noexcept {
     print("          ", make_colored(message, with_color, color::highlight2), "\n");
 }
 
-void registry::print_details_expr(
-    std::string_view check, std::string_view exp_str, const expression& exp) const noexcept {
-
-    small_string<max_message_length> full_check;
-    if (append(full_check, check, "(", exp_str, ")")) {
-        truncate_end(full_check);
-    }
-
-    print("          ", make_colored(full_check, with_color, color::highlight2));
+void registry::print_details_expr(const expression& exp) const noexcept {
+    print("          ", make_colored(exp.content, with_color, color::highlight2));
 
     if (!exp.failed) {
         print(", got ", make_colored(exp.data, with_color, color::highlight2));

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -825,6 +825,8 @@ int main(int argc, char* argv[]) {
             snatch::tests.with_color = true;
         } else if (*opt->value == "never") {
             snatch::tests.with_color = false;
+        } else {
+            terminate_with("unknown color directive; please use one of always|never");
         }
     }
 

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -148,7 +148,7 @@ bool append(small_string_span ss, const colored<T>& colored_value) noexcept {
 }
 
 template<typename... Args>
-void print(Args&&... args) noexcept {
+void console_print(Args&&... args) noexcept {
     small_string<max_message_length> message;
     if (!append(message, std::forward<Args>(args)...)) {
         truncate_end(message);
@@ -165,7 +165,7 @@ bool is_at_least(snatch::registry::verbosity verbose, snatch::registry::verbosit
 
 namespace snatch::impl {
 [[noreturn]] void terminate_with(std::string_view msg) noexcept {
-    print("terminate called with message: ", msg, "\n");
+    console_print("terminate called with message: ", msg, "\n");
     std::terminate();
 }
 } // namespace snatch::impl
@@ -228,23 +228,23 @@ bool run_tests(registry& r, F&& predicate) noexcept {
     }
 
     if (is_at_least(r.verbose, registry::verbosity::normal)) {
-        print("==========================================\n");
+        r.print("==========================================\n");
 
         if (success) {
-            print(
+            r.print(
                 make_colored("success:", r.with_color, color::pass), " all tests passed (",
                 run_count, " test cases, ", assertion_count, " assertions");
         } else {
-            print(
+            r.print(
                 make_colored("error:", r.with_color, color::fail), " some tests failed (",
                 fail_count, " out of ", run_count, " test cases, ", assertion_count, " assertions");
         }
 
         if (skip_count > 0) {
-            print(", ", skip_count, " test cases skipped");
+            r.print(", ", skip_count, " test cases skipped");
         }
 
-        print(")\n");
+        r.print(")\n");
     }
 
     return success;
@@ -258,9 +258,9 @@ void list_tests(const registry& r, F&& predicate) noexcept {
         }
 
         if (!t.type.empty()) {
-            print(t.name, " [", t.type, "]\n");
+            console_print(t.name, " [", t.type, "]\n");
         } else {
-            print(t.name);
+            console_print(t.name);
         }
     }
 }
@@ -591,7 +591,7 @@ std::optional<arguments> parse_arguments(
                 found = true;
 
                 if (expected_found[arg_index]) {
-                    print(
+                    console_print(
                         make_colored("error:", settings.with_color, color::error),
                         " duplicate command line argument '", arg, "'\n");
                     bad = true;
@@ -602,7 +602,7 @@ std::optional<arguments> parse_arguments(
 
                 if (e.value_name) {
                     if (argi + 1 == argc) {
-                        print(
+                        console_print(
                             make_colored("error:", settings.with_color, color::error),
                             " missing value '<", *e.value_name, ">' for command line argument '",
                             arg, "'\n");
@@ -621,7 +621,7 @@ std::optional<arguments> parse_arguments(
             }
 
             if (!found) {
-                print(
+                console_print(
                     make_colored("warning:", settings.with_color, color::warning),
                     " unknown command line argument '", arg, "'\n");
             }
@@ -642,7 +642,7 @@ std::optional<arguments> parse_arguments(
             }
 
             if (!found) {
-                print(
+                console_print(
                     make_colored("error:", settings.with_color, color::error),
                     " too many positional arguments\n");
                 bad = true;
@@ -654,11 +654,11 @@ std::optional<arguments> parse_arguments(
         const auto& e = expected[arg_index];
         if (e.type == argument_type::mandatory && !expected_found[arg_index]) {
             if (e.names.empty()) {
-                print(
+                console_print(
                     make_colored("error:", settings.with_color, color::error),
                     " missing positional argument '<", *e.value_name, ">'\n");
             } else {
-                print(
+                console_print(
                     make_colored("error:", settings.with_color, color::error), " missing option '<",
                     e.names.back(), ">'\n");
             }
@@ -684,26 +684,26 @@ void print_help(
     const print_help_settings& settings = print_help_settings{}) {
 
     // Print program desription
-    print(make_colored(program_description, settings.with_color, color::highlight2), "\n");
+    console_print(make_colored(program_description, settings.with_color, color::highlight2), "\n");
 
     // Print command line usage example
-    print(make_colored("Usage:", settings.with_color, color::pass), "\n");
-    print("  ", program_name);
+    console_print(make_colored("Usage:", settings.with_color, color::pass), "\n");
+    console_print("  ", program_name);
     if (std::any_of(expected.cbegin(), expected.cend(), [](auto& e) { return !e.names.empty(); })) {
-        print(" [options...]");
+        console_print(" [options...]");
     }
 
     for (const auto& e : expected) {
         if (e.names.empty()) {
             if (e.type == argument_type::mandatory) {
-                print(" <", *e.value_name, ">");
+                console_print(" <", *e.value_name, ">");
             } else {
-                print(" [<", *e.value_name, ">]");
+                console_print(" [<", *e.value_name, ">]");
             }
         }
     }
 
-    print("\n\n");
+    console_print("\n\n");
 
     // List arguments
     small_string<max_message_length> heading;
@@ -733,7 +733,7 @@ void print_help(
             terminate_with("argument name is too long");
         }
 
-        print(
+        console_print(
             "  ", make_colored(heading, settings.with_color, color::highlight1), " ", e.description,
             "\n");
     }
@@ -789,7 +789,7 @@ int main(int argc, char* argv[]) {
         parse_arguments(argc, argv, expected, {.with_color = with_color_default});
 
     if (!ret_args || get_option(*ret_args, "--help")) {
-        print("\n");
+        console_print("\n");
         print_help(argv[0], "Snatch test runner"sv, expected, {.with_color = with_color_default});
         return !ret_args ? 1 : 0;
     }

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -531,7 +531,7 @@ parse_arguments(int argc, char* argv[], const expected_arguments& expected) noex
                 found = true;
 
                 if (expected_found[arg_index]) {
-                    printf(
+                    std::printf(
                         "%serror:%s duplicate command line argument '%.*s'\n", color::error_start,
                         color::reset, static_cast<int>(arg.size()), arg.data());
                     bad = true;
@@ -542,7 +542,7 @@ parse_arguments(int argc, char* argv[], const expected_arguments& expected) noex
 
                 if (e.value_name) {
                     if (argi + 1 == argc) {
-                        printf(
+                        std::printf(
                             "%serror:%s missing value '<%.*s>' for command line argument '%.*s'\n",
                             color::error_start, color::reset,
                             static_cast<int>(e.value_name->size()), e.value_name->data(),
@@ -562,7 +562,7 @@ parse_arguments(int argc, char* argv[], const expected_arguments& expected) noex
             }
 
             if (!found) {
-                printf(
+                std::printf(
                     "%swarning:%s unknown command line argument '%.*s'\n", color::warning_start,
                     color::reset, static_cast<int>(arg.size()), arg.data());
             }
@@ -583,7 +583,7 @@ parse_arguments(int argc, char* argv[], const expected_arguments& expected) noex
             }
 
             if (!found) {
-                printf(
+                std::printf(
                     "%serror:%s too many positional arguments\n", color::error_start, color::reset);
                 bad = true;
             }
@@ -594,11 +594,11 @@ parse_arguments(int argc, char* argv[], const expected_arguments& expected) noex
         const auto& e = expected[arg_index];
         if (e.type == argument_type::mandatory && !expected_found[arg_index]) {
             if (e.names.empty()) {
-                printf(
+                std::printf(
                     "%serror:%s missing positional argument '<%.*s>'\n", color::error_start,
                     color::reset, static_cast<int>(e.value_name->size()), e.value_name->data());
             } else {
-                printf(
+                std::printf(
                     "%serror:%s missing option '<%.*s>'\n", color::error_start, color::reset,
                     static_cast<int>(e.names.back().size()), e.names.back().data());
             }
@@ -619,49 +619,52 @@ void print_help(
     const expected_arguments& expected) {
 
     // Print program desription
-    printf(
+    std::printf(
         "%s%.*s%s\n", color::highlight2_start, static_cast<int>(program_description.size()),
         program_description.data(), color::reset);
 
     // Print command line usage example
-    printf("%sUsage:%s\n", color::pass_start, color::reset);
-    printf("  %.*s", static_cast<int>(program_name.size()), program_name.data());
+    std::printf("%sUsage:%s\n", color::pass_start, color::reset);
+    std::printf("  %.*s", static_cast<int>(program_name.size()), program_name.data());
     if (std::any_of(expected.cbegin(), expected.cend(), [](auto& e) { return !e.names.empty(); })) {
-        printf(" [options...]");
+        std::printf(" [options...]");
     }
     for (const auto& e : expected) {
         if (e.names.empty()) {
             if (e.type == argument_type::mandatory) {
-                printf(" <%.*s>", static_cast<int>(e.value_name->size()), e.value_name->data());
+                std::printf(
+                    " <%.*s>", static_cast<int>(e.value_name->size()), e.value_name->data());
             } else {
-                printf(" [<%.*s>]", static_cast<int>(e.value_name->size()), e.value_name->data());
+                std::printf(
+                    " [<%.*s>]", static_cast<int>(e.value_name->size()), e.value_name->data());
             }
         }
     }
-    printf("\n\n");
+    std::printf("\n\n");
 
     // List arguments
     for (const auto& e : expected) {
-        printf("  ");
-        printf("%s", color::highlight1_start);
+        std::printf("  ");
+        std::printf("%s", color::highlight1_start);
         if (!e.names.empty()) {
             if (e.names[0].starts_with("--")) {
-                printf("    ");
+                std::printf("    ");
             }
 
-            printf("%.*s", static_cast<int>(e.names[0].size()), e.names[0].data());
+            std::printf("%.*s", static_cast<int>(e.names[0].size()), e.names[0].data());
             if (e.names.size() == 2) {
-                printf(", %.*s", static_cast<int>(e.names[1].size()), e.names[1].data());
+                std::printf(", %.*s", static_cast<int>(e.names[1].size()), e.names[1].data());
             }
 
             if (e.value_name) {
-                printf(" <%.*s>", static_cast<int>(e.value_name->size()), e.value_name->data());
+                std::printf(
+                    " <%.*s>", static_cast<int>(e.value_name->size()), e.value_name->data());
             }
         } else {
-            printf("<%.*s>", static_cast<int>(e.value_name->size()), e.value_name->data());
+            std::printf("<%.*s>", static_cast<int>(e.value_name->size()), e.value_name->data());
         }
-        printf("%s", color::reset);
-        printf(" %.*s\n", static_cast<int>(e.description.size()), e.description.data());
+        std::printf("%s", color::reset);
+        std::printf(" %.*s\n", static_cast<int>(e.description.size()), e.description.data());
     }
 }
 
@@ -710,7 +713,7 @@ int main(int argc, char* argv[]) {
 
     std::optional<arguments> ret_args = parse_arguments(argc, argv, expected);
     if (!ret_args) {
-        printf("\n");
+        std::printf("\n");
         print_help(argv[0], "Snatch test runner"sv, expected);
         return 1;
     }

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -132,6 +132,74 @@ void truncate_end(small_string_span ss) noexcept {
     std::memcpy(ss.begin() + offset, "...", num_dots);
 }
 
+bool replace_all(
+    impl::small_string_span string,
+    std::string_view        pattern,
+    std::string_view        replacement) noexcept {
+
+    if (replacement.size() == pattern.size()) {
+        std::string_view sv(string.begin(), string.size());
+        auto             pos = sv.find_first_of(pattern);
+
+        while (pos != sv.npos) {
+            // Replace pattern by replacement
+            std::memcpy(string.begin() + pos, replacement.begin(), replacement.size());
+            pos += replacement.size();
+
+            // Find next occurrence
+            pos = sv.find(pattern, pos);
+        }
+
+        return true;
+    } else if (replacement.size() < pattern.size()) {
+        const std::size_t char_diff = pattern.size() - replacement.size();
+        std::string_view  sv(string.begin(), string.size());
+        auto              pos = sv.find(pattern);
+
+        while (pos != sv.npos) {
+            // Shift data after the replacement to the left to fill the gap
+            std::rotate(string.begin() + pos, string.begin() + pos + char_diff, string.end());
+            string.resize(string.size() - char_diff);
+
+            // Replace pattern by replacement
+            std::memcpy(string.begin() + pos, replacement.begin(), replacement.size());
+            pos += replacement.size();
+
+            // Find next occurrence
+            sv  = {string.begin(), string.size()};
+            pos = sv.find(pattern, pos);
+        }
+
+        return true;
+    } else {
+        const std::size_t char_diff = replacement.size() - pattern.size();
+        std::string_view  sv(string.begin(), string.size());
+        auto              pos      = sv.find(pattern);
+        bool              overflow = false;
+
+        while (pos != sv.npos) {
+            // Shift data after the pattern to the right to make room for the replacement
+            const std::size_t char_growth = std::min(char_diff, string.available());
+            if (char_growth != char_diff) {
+                overflow = true;
+            }
+            string.grow(char_growth);
+            std::rotate(string.begin() + pos, string.end() - char_growth, string.end());
+
+            // Replace pattern by replacement
+            const std::size_t max_chars = pattern.size() + char_growth;
+            std::memcpy(string.begin() + pos, replacement.begin(), max_chars);
+            pos += max_chars;
+
+            // Find next occurrence
+            sv  = {string.begin(), string.size()};
+            pos = sv.find(pattern, pos);
+        }
+
+        return !overflow;
+    }
+}
+
 void stddout_print(std::string_view message) noexcept {
     // TODO: replace this with std::print?
     std::printf("%.*s", static_cast<int>(message.length()), message.data());

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -44,7 +44,7 @@ colored<T> make_colored(const T& t, bool with_color, color_t start) {
 } // namespace
 
 namespace {
-using snatch::impl::small_string_span;
+using snatch::small_string_span;
 
 template<typename T>
 constexpr const char* get_format_code() noexcept {
@@ -82,7 +82,7 @@ bool append_fmt(small_string_span ss, T value) noexcept {
 }
 } // namespace
 
-namespace snatch::impl {
+namespace snatch {
 bool append(small_string_span ss, std::string_view str) noexcept {
     const bool        could_fit  = str.size() <= ss.available();
     const std::size_t copy_count = std::min(str.size(), ss.available());
@@ -133,9 +133,7 @@ void truncate_end(small_string_span ss) noexcept {
 }
 
 bool replace_all(
-    impl::small_string_span string,
-    std::string_view        pattern,
-    std::string_view        replacement) noexcept {
+    small_string_span string, std::string_view pattern, std::string_view replacement) noexcept {
 
     if (replacement.size() == pattern.size()) {
         std::string_view sv(string.begin(), string.size());
@@ -199,7 +197,9 @@ bool replace_all(
         return !overflow;
     }
 }
+} // namespace snatch
 
+namespace snatch::impl {
 void stddout_print(std::string_view message) noexcept {
     // TODO: replace this with std::print?
     std::printf("%.*s", static_cast<int>(message.length()), message.data());
@@ -208,7 +208,8 @@ void stddout_print(std::string_view message) noexcept {
 
 namespace {
 using snatch::max_message_length;
-using snatch::impl::small_string;
+using snatch::small_string;
+using snatch::impl::stddout_print;
 
 template<typename T>
 bool append(small_string_span ss, const colored<T>& colored_value) noexcept {
@@ -231,12 +232,12 @@ bool is_at_least(snatch::registry::verbosity verbose, snatch::registry::verbosit
 }
 } // namespace
 
-namespace snatch::impl {
+namespace snatch {
 [[noreturn]] void terminate_with(std::string_view msg) noexcept {
     console_print("terminate called with message: ", msg, "\n");
     std::terminate();
 }
-} // namespace snatch::impl
+} // namespace snatch
 
 // Matcher implementation.
 // -----------------------
@@ -586,7 +587,7 @@ bool registry::run_tests_with_tag(std::string_view run_name, std::string_view ta
 }
 
 void registry::list_all_tags() const noexcept {
-    impl::small_vector<std::string_view, max_unique_tags> tags;
+    small_vector<std::string_view, max_unique_tags> tags;
     for (const auto& t : test_list) {
         for_each_tag(t.id.tags, [&](std::string_view v) {
             if (std::find(tags.begin(), tags.end(), v) == tags.end()) {

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -141,7 +141,7 @@ bool replace_all(
 
         while (pos != sv.npos) {
             // Replace pattern by replacement
-            std::memcpy(string.begin() + pos, replacement.begin(), replacement.size());
+            std::memcpy(string.data() + pos, replacement.data(), replacement.size());
             pos += replacement.size();
 
             // Find next occurrence
@@ -160,7 +160,7 @@ bool replace_all(
             string.resize(string.size() - char_diff);
 
             // Replace pattern by replacement
-            std::memcpy(string.begin() + pos, replacement.begin(), replacement.size());
+            std::memcpy(string.data() + pos, replacement.data(), replacement.size());
             pos += replacement.size();
 
             // Find next occurrence
@@ -186,7 +186,7 @@ bool replace_all(
 
             // Replace pattern by replacement
             const std::size_t max_chars = pattern.size() + char_growth;
-            std::memcpy(string.begin() + pos, replacement.begin(), max_chars);
+            std::memcpy(string.data() + pos, replacement.data(), max_chars);
             pos += max_chars;
 
             // Find next occurrence

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -560,13 +560,13 @@ void registry::run(test_case& t) noexcept {
 }
 
 bool registry::run_all_tests(std::string_view run_name) noexcept {
-    return run_tests(*this, run_name, [](const test_case&) { return true; });
+    return ::run_tests(*this, run_name, [](const test_case&) { return true; });
 }
 
 bool registry::run_tests_matching_name(
     std::string_view run_name, std::string_view name_filter) noexcept {
     small_string<max_test_name_length> buffer;
-    return run_tests(*this, run_name, [&](const test_case& t) {
+    return ::run_tests(*this, run_name, [&](const test_case& t) {
         std::string_view v = make_full_name(buffer, t.id);
 
         // TODO: use regex here?
@@ -575,7 +575,7 @@ bool registry::run_tests_matching_name(
 }
 
 bool registry::run_tests_with_tag(std::string_view run_name, std::string_view tag_filter) noexcept {
-    return run_tests(*this, run_name, [&](const test_case& t) {
+    return ::run_tests(*this, run_name, [&](const test_case& t) {
         bool selected = false;
         for_each_tag(t.id.tags, [&](std::string_view v) {
             if (v == tag_filter) {
@@ -945,7 +945,7 @@ std::optional<cli::input> parse_arguments(int argc, char* argv[]) noexcept {
 } // namespace snatch::cli
 
 namespace snatch {
-void registry::configure_from_command_line(const cli::input& args) noexcept {
+void registry::configure(const cli::input& args) noexcept {
     if (auto opt = get_option(args, "--color")) {
         if (*opt->value == "always") {
             snatch::tests.with_color = true;
@@ -973,7 +973,7 @@ void registry::configure_from_command_line(const cli::input& args) noexcept {
     }
 }
 
-bool registry::run_tests_from_command_line(const cli::input& args) noexcept {
+bool registry::run_tests(const cli::input& args) noexcept {
     if (get_option(args, "--help")) {
         console_print("\n");
         print_help(
@@ -1020,9 +1020,9 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
-    snatch::tests.configure_from_command_line(*args);
+    snatch::tests.configure(*args);
 
-    return snatch::tests.run_tests_from_command_line(*args) ? 0 : 1;
+    return snatch::tests.run_tests(*args) ? 0 : 1;
 }
 
 #endif

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -214,7 +214,7 @@ bool run_tests(registry& r, F&& predicate) noexcept {
         r.run(t);
 
         ++run_count;
-        assertion_count += t.tests;
+        assertion_count += t.asserts;
         if (t.state == test_state::failed) {
             ++fail_count;
             success = false;
@@ -375,8 +375,8 @@ void registry::run(test_case& t) noexcept {
             make_colored(full_name, with_color, color::highlight1), "\n");
     }
 
-    t.tests = 0;
-    t.state = test_state::success;
+    t.asserts = 0;
+    t.state   = test_state::success;
 
 #if SNATCH_WITH_EXCEPTIONS
     try {

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -121,11 +121,6 @@ bool append(small_string_span ss, double d) noexcept {
 bool append(small_string_span ss, bool value) noexcept {
     return append(ss, value ? "true" : "false");
 }
-} // namespace snatch::impl
-
-namespace {
-using snatch::max_message_length;
-using snatch::impl::small_string;
 
 void truncate_end(small_string_span ss) noexcept {
     std::size_t num_dots     = 3;
@@ -137,6 +132,16 @@ void truncate_end(small_string_span ss) noexcept {
     std::memcpy(ss.begin() + offset, "...", num_dots);
 }
 
+void default_print(std::string_view message) noexcept {
+    // TODO: replace this with std::print?
+    std::printf("%.*s", static_cast<int>(message.length()), message.data());
+}
+} // namespace snatch::impl
+
+namespace {
+using snatch::max_message_length;
+using snatch::impl::small_string;
+
 template<typename T>
 bool append(small_string_span ss, const colored<T>& colored_value) noexcept {
     return append(ss, colored_value.color_start, colored_value.value, colored_value.color_end);
@@ -144,13 +149,12 @@ bool append(small_string_span ss, const colored<T>& colored_value) noexcept {
 
 template<typename... Args>
 void print(Args&&... args) noexcept {
-    // TODO: replace this with std::print
     small_string<max_message_length> message;
     if (!append(message, std::forward<Args>(args)...)) {
         truncate_end(message);
     }
 
-    std::printf("%.*s", static_cast<int>(message.length()), message.data());
+    default_print(message);
 }
 
 bool is_at_least(snatch::registry::verbosity verbose, snatch::registry::verbosity required) {
@@ -369,7 +373,6 @@ void registry::run(test_case& t) noexcept {
     small_string<max_test_name_length> full_name;
     if (is_at_least(verbose, verbosity::high)) {
         make_full_name(full_name, t);
-
         print(
             make_colored("starting:", with_color, color::status), " ",
             make_colored(full_name, with_color, color::highlight1), "\n");

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -132,7 +132,7 @@ void truncate_end(small_string_span ss) noexcept {
     std::memcpy(ss.begin() + offset, "...", num_dots);
 }
 
-void default_print(std::string_view message) noexcept {
+void stddout_print(std::string_view message) noexcept {
     // TODO: replace this with std::print?
     std::printf("%.*s", static_cast<int>(message.length()), message.data());
 }
@@ -154,7 +154,7 @@ void print(Args&&... args) noexcept {
         truncate_end(message);
     }
 
-    default_print(message);
+    stddout_print(message);
 }
 
 bool is_at_least(snatch::registry::verbosity verbose, snatch::registry::verbosity required) {

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -290,14 +290,14 @@ void for_each_tag(std::string_view s, F&& callback) noexcept {
 }
 
 std::string_view
-make_full_name(small_string<max_test_name_length>& buffer, const test_case& t) noexcept {
+make_full_name(small_string<max_test_name_length>& buffer, const test_id& id) noexcept {
     buffer.clear();
-    if (t.id.type.length() != 0) {
-        if (!append(buffer, t.id.name, " [", t.id.type, "]")) {
+    if (id.type.length() != 0) {
+        if (!append(buffer, id.name, " [", id.type, "]")) {
             return {};
         }
     } else {
-        if (!append(buffer, t.id.name)) {
+        if (!append(buffer, id.name)) {
             return {};
         }
     }
@@ -327,7 +327,7 @@ void registry::register_test(const test_id& id, test_ptr func) noexcept {
     test_list.push_back(test_case{id, func});
 
     small_string<max_test_name_length> buffer;
-    if (make_full_name(buffer, test_list.back()).empty()) {
+    if (make_full_name(buffer, test_list.back().id).empty()) {
         print(
             make_colored("error:", with_color, color::fail),
             " max length of test name reached; "
@@ -457,7 +457,7 @@ void registry::run(test_case& t) noexcept {
     if (report_callback != nullptr) {
         (*report_callback)(event::test_case_started{t.id});
     } else if (is_at_least(verbose, verbosity::high)) {
-        make_full_name(full_name, t);
+        make_full_name(full_name, t.id);
         print(
             make_colored("starting:", with_color, color::status), " ",
             make_colored(full_name, with_color, color::highlight1), "\n");
@@ -498,7 +498,7 @@ bool registry::run_tests_matching_name(
     std::string_view run_name, std::string_view name_filter) noexcept {
     small_string<max_test_name_length> buffer;
     return run_tests(*this, run_name, [&](const test_case& t) {
-        std::string_view v = make_full_name(buffer, t);
+        std::string_view v = make_full_name(buffer, t.id);
 
         // TODO: use regex here?
         return v.find(name_filter) != v.npos;

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -200,7 +200,7 @@ bool replace_all(
 } // namespace snatch
 
 namespace snatch::impl {
-void stddout_print(std::string_view message) noexcept {
+void stdout_print(std::string_view message) noexcept {
     // TODO: replace this with std::print?
     std::printf("%.*s", static_cast<int>(message.length()), message.data());
 }
@@ -209,7 +209,7 @@ void stddout_print(std::string_view message) noexcept {
 namespace {
 using snatch::max_message_length;
 using snatch::small_string;
-using snatch::impl::stddout_print;
+using snatch::impl::stdout_print;
 
 template<typename T>
 bool append(small_string_span ss, const colored<T>& colored_value) noexcept {
@@ -223,7 +223,7 @@ void console_print(Args&&... args) noexcept {
         truncate_end(message);
     }
 
-    stddout_print(message);
+    stdout_print(message);
 }
 
 bool is_at_least(snatch::registry::verbosity verbose, snatch::registry::verbosity required) {


### PR DESCRIPTION
This PR does the following.

For #8:
 - Add a new member to `registry`, `with_color`, which is `true` if color should be used in messages and `false` otherwise.
 - Add a new command line parameter `--color`, to enable/disable color in messages.
 - Add a new configuration pre-processor variable `SNATCH_DEFAULT_WITH_COLOR` to change the default behavior of _snatch_ regarding whether color codes are used in the standard output. Custom reporters may be affected by this variable if they choose to use `registry::with_color`.

For #6:
 - Promoted `registry::verbose` from a boolean to an enum similar to _Catch2_. Custom reports may be affected by this variable if they choose to use it.
 - Added `snatch::event` namespace, events, and the `data` type to hold all possible events.
 - Added `registry::print_callback` to customize the function that prints output messages (default it to use standard output).
 - Added `registry::report_callback` to customize the function that formats test messages (default or if null, use _snatch_ format).
 - Measure the time taken by each test, will be reported only if verbosity is `high` by default.
 - Added an example reporter callback for Teamcity.

Other miscellaneous changes:
 - Brought the main command-line interface functions to the `snatch::cli` namespace for public use.
 - Refactored testing macros to speed up compilation and reduce code duplication.
 - Refactored test name, type, and tags into `test_id` for public use.
 - Moved all `small_*` types and related helper functions to the `snatch` namespace for public use.
 - Added `small_function` to store user callbacks.
 - Added `replace_all` to replace all occurrences in a small string.
 - Renamed `SNATCH_MAX_MATCHER_MSG_LENGTH` to `SNATCH_MAX_MESSAGE_LENGTH`, and expand its impact to all messages that get written to a temporary buffer for printing.
 - Added benchmark against _Boost UT_.