### PR TITLE
Add `SECTION()`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.8)
 project(snatch LANGUAGES CXX VERSION 1.0)
 
 set(SNATCH_MAX_TEST_CASES         5000 CACHE STRING "Maximum number of test cases in a test application.")
+set(SNATCH_MAX_NESTED_SECTIONS    8    CACHE STRING "Maximum depth of nested sections in a test case.")
 set(SNATCH_MAX_EXPR_LENGTH        1024 CACHE STRING "Maximum length of a printed expression when reporting failure.")
 set(SNATCH_MAX_MESSAGE_LENGTH     1024 CACHE STRING "Maximum length of error or status messages.")
 set(SNATCH_MAX_TEST_NAME_LENGTH   1024 CACHE STRING "Maximum length of a test case name.")
@@ -24,6 +25,7 @@ target_include_directories(snatch PUBLIC
 
 target_compile_definitions(snatch PUBLIC
   SNATCH_MAX_TEST_CASES=${SNATCH_MAX_TEST_CASES}
+  SNATCH_MAX_NESTED_SECTIONS=${SNATCH_MAX_NESTED_SECTIONS}
   SNATCH_MAX_EXPR_LENGTH=${SNATCH_MAX_EXPR_LENGTH}
   SNATCH_MAX_MESSAGE_LENGTH=${SNATCH_MAX_MESSAGE_LENGTH}
   SNATCH_MAX_TEST_NAME_LENGTH=${SNATCH_MAX_TEST_NAME_LENGTH}

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The goal of _snatch_ is to be a simple, cheap, non-invasive, and user-friendly t
     - [Test case macros](#test-case-macros)
     - [Test check macros](#test-check-macros)
     - [Matchers](#matchers)
+    - [Sections](#sections)
     - [Reporters](#reporters)
     - [Default main function](#default-main-function)
     - [Using your own main function](#using-your-own-main-function)
@@ -32,6 +33,7 @@ The goal of _snatch_ is to be a simple, cheap, non-invasive, and user-friendly t
    - Typed test cases with `TEMPLATE_LIST_TEST_CASE(name, tags, types)`.
    - Pretty-printing check macros: `REQUIRE(expr)`, `CHECK(expr)`, `FAIL(msg)`, `FAIL_CHECK(msg)`.
    - Exception checking macros: `REQUIRE_THROWS_AS(expr, except)`, `CHECK_THROWS_AS(expr, except)`, `REQUIRE_THROWS_MATCHES(expr, exception, matcher)`, `CHECK_THROWS_MATCHES(expr, except, matcher)`.
+   - Nesting multiple tests in a single test case with `SECTION(name)`.
    - Optional `main()` with simple command-line API similar to _Catch2_.
  - Additional API not in _Catch2_, or different from _Catch2_:
    - Macro to mark a test as skipped: `SKIP(msg)`.
@@ -44,7 +46,6 @@ Notable current limitations:
  - Test macros (`REQUIRE(...)`, etc.) may only be used inside the test body (or in lambdas defined in the test body), and cannot be used in other functions.
  - No set-up/tear-down helpers.
  - No multi-threaded test execution.
- - No `SECTION(...)`.
 
 
 ## Example
@@ -109,6 +110,8 @@ Description of results below:
  - *Run tests*: Total time require to run the tests.
  - *Library size*: Size of the compiled testing framework library (if any).
  - *Executable size*: Size of the compiled test executable, static linking to the testing framework library (if any).
+
+TODO: update after adding sections.
 
 Results for _snatch_:
 
@@ -211,6 +214,11 @@ Two matchers are provided with _snatch_:
 
  - `snatch::matchers::contains_substring{"substring"}`: accepts a `std::string_view`, and will return a match if the string contains `"substring"`.
  - `snatch::matchers::with_what_contains{"substring"}`: accepts a `std::exception`, and will return a match if `what()` contains `"substring"`.
+
+
+### Sections
+
+TODO.
 
 
 ### Reporters

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The goal of _snatch_ is to be a simple, cheap, non-invasive, and user-friendly t
    - Typed test cases with `TEMPLATE_LIST_TEST_CASE(name, tags, types)`.
    - Pretty-printing check macros: `REQUIRE(expr)`, `CHECK(expr)`, `FAIL(msg)`, `FAIL_CHECK(msg)`.
    - Exception checking macros: `REQUIRE_THROWS_AS(expr, except)`, `CHECK_THROWS_AS(expr, except)`, `REQUIRE_THROWS_MATCHES(expr, exception, matcher)`, `CHECK_THROWS_MATCHES(expr, except, matcher)`.
-   - Nesting multiple tests in a single test case with `SECTION(name)`.
+   - Nesting multiple tests in a single test case with `SECTION(name, description)`.
    - Optional `main()` with simple command-line API similar to _Catch2_.
  - Additional API not in _Catch2_, or different from _Catch2_:
    - Macro to mark a test as skipped: `SKIP(msg)`.

--- a/README.md
+++ b/README.md
@@ -218,7 +218,52 @@ Two matchers are provided with _snatch_:
 
 ### Sections
 
-TODO.
+As in _Catch2_, _snatch_ supports nesting multiple tests inside a single test case, to share set-up/tear-down logic. This is done using the `SECTION("name")` macro. Please see the [Catch2 documentation](https://github.com/catchorg/Catch2/blob/devel/docs/tutorial.md#test-cases-and-sections) for more details. Here is a brief example to demonstrate the flow of the test:
+
+```c++
+TEST_CASE( "test with sections", "[section]" ) {
+    std::cout << "set-up" << std::endl;
+    // shared set-up logic here...
+
+    SECTION( "first section" ) {
+        std::cout << " 1" << std::endl;
+    }
+    SECTION( "second section" ) {
+        std::cout << " 2" << std::endl;
+    }
+    SECTION( "third section" ) {
+        std::cout << " 3" << std::endl;
+        SECTION( "nested section 1" ) {
+            std::cout << "  3.1" << std::endl;
+        }
+        SECTION( "nested section 2" ) {
+            std::cout << "  3.2" << std::endl;
+        }
+    }
+
+    std::cout << "tear-down" << std::endl;
+    // shared tear-down logic here...
+};
+```
+
+The output of this test will be:
+```
+set-up
+ 1
+tear-down
+set-up
+ 2
+tear-down
+set-up
+ 3
+  3.1
+tear-down
+set-up
+ 3
+  3.2
+tear-down
+
+```
 
 
 ### Reporters

--- a/README.md
+++ b/README.md
@@ -111,18 +111,16 @@ Description of results below:
  - *Library size*: Size of the compiled testing framework library (if any).
  - *Executable size*: Size of the compiled test executable, static linking to the testing framework library (if any).
 
-TODO: update after adding sections.
-
 Results for _snatch_:
 
 |                 | _snatch_ (Debug) | _snatch_ (Release) |
 |-----------------|------------------|--------------------|
-| Build framework | 1.5s             | 2.2s               |
+| Build framework | 1.6s             | 2.4s               |
 | Build tests     | 65s              | 133s               |
 | Build all       | 67s              | 135s               |
-| Run tests       | 13ms             | 7ms                |
-| Library size    | 2.50MB           | 0.63MB             |
-| Executable size | 28.9MB           | 8.5MB              |
+| Run tests       | 15ms             | 8ms                |
+| Library size    | 2.70MB           | 0.68MB             |
+| Executable size | 29.9MB           | 8.8MB              |
 
 Results for alternative testing frameworks:
 

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -227,6 +227,13 @@ public:
 
         return elem;
     }
+    constexpr void pop_back() noexcept {
+        if (*data_size == 0) {
+            terminate_with("pop_back() called on empty vector");
+        }
+
+        --*data_size;
+    }
     constexpr ElemType& back() noexcept {
         if (*data_size == 0) {
             terminate_with("back() called on empty vector");
@@ -320,6 +327,9 @@ public:
     template<typename U>
     constexpr ElemType& push_back(U&& t) noexcept(noexcept(this->span().push_back(t))) {
         return this->span().push_back(t);
+    }
+    constexpr void pop_back() noexcept {
+        return span().pop_back();
     }
     constexpr ElemType& back() noexcept {
         return span().back();
@@ -418,6 +428,9 @@ public:
     }
     constexpr char& push_back(char t) noexcept {
         return span().push_back(t);
+    }
+    constexpr void pop_back() noexcept {
+        return span().pop_back();
     }
     constexpr char& back() noexcept {
         return span().back();

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -892,22 +892,22 @@ struct with_what_contains : private contains_substring {
 #define SNATCH_TEST_CASE(NAME, TAGS)                                                               \
     static const char* SNATCH_MACRO_CONCAT(test_id_, __COUNTER__) =                                \
         snatch::tests.add(NAME, TAGS) =                                                            \
-            [](snatch::impl::test_case & CURRENT_CASE [[maybe_unused]]) -> void
+            [](snatch::impl::test_case & SNATCH_CURRENT_CASE [[maybe_unused]]) -> void
 
 #define SNATCH_TEMPLATE_LIST_TEST_CASE(NAME, TAGS, TYPES)                                          \
     static const char* SNATCH_MACRO_CONCAT(test_id_, __COUNTER__) =                                \
-        snatch::tests.add_with_types<TYPES>(NAME, TAGS) =                                          \
-            []<typename TestType>(snatch::impl::test_case & CURRENT_CASE [[maybe_unused]]) -> void
+        snatch::tests.add_with_types<TYPES>(NAME, TAGS) = []<typename TestType>(                   \
+            snatch::impl::test_case & SNATCH_CURRENT_CASE [[maybe_unused]]) -> void
 
 #define SNATCH_REQUIRE(EXP)                                                                        \
     do {                                                                                           \
-        ++CURRENT_CASE.asserts;                                                                    \
+        ++SNATCH_CURRENT_CASE.asserts;                                                             \
         SNATCH_WARNING_PUSH;                                                                       \
         SNATCH_WARNING_DISABLE_PARENTHESES;                                                        \
         SNATCH_WARNING_DISABLE_CONSTANT_COMPARISON;                                                \
         if (!(EXP)) {                                                                              \
             snatch::tests.report_failure(                                                          \
-                CURRENT_CASE, {__FILE__, __LINE__}, SNATCH_EXPR("REQUIRE", EXP));                  \
+                SNATCH_CURRENT_CASE, {__FILE__, __LINE__}, SNATCH_EXPR("REQUIRE", EXP));           \
             SNATCH_TESTING_ABORT;                                                                  \
         }                                                                                          \
         SNATCH_WARNING_POP;                                                                        \
@@ -915,31 +915,31 @@ struct with_what_contains : private contains_substring {
 
 #define SNATCH_CHECK(EXP)                                                                          \
     do {                                                                                           \
-        ++CURRENT_CASE.asserts;                                                                    \
+        ++SNATCH_CURRENT_CASE.asserts;                                                             \
         SNATCH_WARNING_PUSH;                                                                       \
         SNATCH_WARNING_DISABLE_PARENTHESES;                                                        \
         SNATCH_WARNING_DISABLE_CONSTANT_COMPARISON;                                                \
         if (!(EXP)) {                                                                              \
             snatch::tests.report_failure(                                                          \
-                CURRENT_CASE, {__FILE__, __LINE__}, SNATCH_EXPR("CHECK", EXP));                    \
+                SNATCH_CURRENT_CASE, {__FILE__, __LINE__}, SNATCH_EXPR("CHECK", EXP));             \
         }                                                                                          \
         SNATCH_WARNING_POP;                                                                        \
     } while (0)
 
 #define SNATCH_FAIL(MESSAGE)                                                                       \
     do {                                                                                           \
-        snatch::tests.report_failure(CURRENT_CASE, {__FILE__, __LINE__}, (MESSAGE));               \
+        snatch::tests.report_failure(SNATCH_CURRENT_CASE, {__FILE__, __LINE__}, (MESSAGE));        \
         SNATCH_TESTING_ABORT;                                                                      \
     } while (0)
 
 #define SNATCH_FAIL_CHECK(MESSAGE)                                                                 \
     do {                                                                                           \
-        snatch::tests.report_failure(CURRENT_CASE, {__FILE__, __LINE__}, (MESSAGE));               \
+        snatch::tests.report_failure(SNATCH_CURRENT_CASE, {__FILE__, __LINE__}, (MESSAGE));        \
     } while (0)
 
 #define SNATCH_SKIP(MESSAGE)                                                                       \
     do {                                                                                           \
-        snatch::tests.report_skipped(CURRENT_CASE, {__FILE__, __LINE__}, (MESSAGE));               \
+        snatch::tests.report_skipped(SNATCH_CURRENT_CASE, {__FILE__, __LINE__}, (MESSAGE));        \
         SNATCH_TESTING_ABORT;                                                                      \
     } while (0)
 
@@ -969,12 +969,12 @@ struct with_what_contains : private contains_substring {
                     throw;                                                                         \
                 } catch (const std::exception& e) {                                                \
                     snatch::tests.report_failure(                                                  \
-                        CURRENT_CASE, {__FILE__, __LINE__},                                        \
+                        SNATCH_CURRENT_CASE, {__FILE__, __LINE__},                                 \
                         #EXCEPTION " expected but other std::exception thrown; message: ",         \
                         e.what());                                                                 \
                 } catch (...) {                                                                    \
                     snatch::tests.report_failure(                                                  \
-                        CURRENT_CASE, {__FILE__, __LINE__},                                        \
+                        SNATCH_CURRENT_CASE, {__FILE__, __LINE__},                                 \
                         #EXCEPTION " expected but other unknown exception thrown");                \
                 }                                                                                  \
                 SNATCH_TESTING_ABORT;                                                              \
@@ -993,12 +993,12 @@ struct with_what_contains : private contains_substring {
                     throw;                                                                         \
                 } catch (const std::exception& e) {                                                \
                     snatch::tests.report_failure(                                                  \
-                        CURRENT_CASE, {__FILE__, __LINE__},                                        \
+                        SNATCH_CURRENT_CASE, {__FILE__, __LINE__},                                 \
                         #EXCEPTION " expected but other std::exception thrown; message: ",         \
                         e.what());                                                                 \
                 } catch (...) {                                                                    \
                     snatch::tests.report_failure(                                                  \
-                        CURRENT_CASE, {__FILE__, __LINE__},                                        \
+                        SNATCH_CURRENT_CASE, {__FILE__, __LINE__},                                 \
                         #EXCEPTION " expected but other unknown exception thrown");                \
                 }                                                                                  \
             }                                                                                      \
@@ -1012,7 +1012,7 @@ struct with_what_contains : private contains_substring {
             } catch (const EXCEPTION& e) {                                                         \
                 if (!(MATCHER).match(e)) {                                                         \
                     snatch::tests.report_failure(                                                  \
-                        CURRENT_CASE, {__FILE__, __LINE__},                                        \
+                        SNATCH_CURRENT_CASE, {__FILE__, __LINE__},                                 \
                         "could not match caught " #EXCEPTION " with expected content: ",           \
                         (MATCHER).describe_fail(e));                                               \
                     SNATCH_TESTING_ABORT;                                                          \
@@ -1022,12 +1022,12 @@ struct with_what_contains : private contains_substring {
                     throw;                                                                         \
                 } catch (const std::exception& e) {                                                \
                     snatch::tests.report_failure(                                                  \
-                        CURRENT_CASE, {__FILE__, __LINE__},                                        \
+                        SNATCH_CURRENT_CASE, {__FILE__, __LINE__},                                 \
                         #EXCEPTION " expected but other std::exception thrown; message: ",         \
                         e.what());                                                                 \
                 } catch (...) {                                                                    \
                     snatch::tests.report_failure(                                                  \
-                        CURRENT_CASE, {__FILE__, __LINE__},                                        \
+                        SNATCH_CURRENT_CASE, {__FILE__, __LINE__},                                 \
                         #EXCEPTION " expected but other unknown exception thrown");                \
                 }                                                                                  \
                 SNATCH_TESTING_ABORT;                                                              \
@@ -1042,7 +1042,7 @@ struct with_what_contains : private contains_substring {
             } catch (const EXCEPTION& e) {                                                         \
                 if (!(MATCHER).match(e)) {                                                         \
                     snatch::tests.report_failure(                                                  \
-                        CURRENT_CASE, {__FILE__, __LINE__},                                        \
+                        SNATCH_CURRENT_CASE, {__FILE__, __LINE__},                                 \
                         "could not match caught " #EXCEPTION " with expected content: ",           \
                         (MATCHER).describe_fail(e));                                               \
                 }                                                                                  \
@@ -1051,12 +1051,12 @@ struct with_what_contains : private contains_substring {
                     throw;                                                                         \
                 } catch (const std::exception& e) {                                                \
                     snatch::tests.report_failure(                                                  \
-                        CURRENT_CASE, {__FILE__, __LINE__},                                        \
+                        SNATCH_CURRENT_CASE, {__FILE__, __LINE__},                                 \
                         #EXCEPTION " expected but other std::exception thrown; message: ",         \
                         e.what());                                                                 \
                 } catch (...) {                                                                    \
                     snatch::tests.report_failure(                                                  \
-                        CURRENT_CASE, {__FILE__, __LINE__},                                        \
+                        SNATCH_CURRENT_CASE, {__FILE__, __LINE__},                                 \
                         #EXCEPTION " expected but other unknown exception thrown");                \
                 }                                                                                  \
             }                                                                                      \

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -928,8 +928,8 @@ struct with_what_contains : private contains_substring {
 #endif
 // clang-format on
 
-// Test macros.
-// ------------
+// Internal test macros.
+// ---------------------
 
 #if SNATCH_WITH_EXCEPTIONS
 #    define SNATCH_TESTING_ABORT                                                                   \
@@ -943,6 +943,9 @@ struct with_what_contains : private contains_substring {
 #define SNATCH_MACRO_DISPATCH2(_1, _2, NAME, ...) NAME
 
 #define SNATCH_EXPR(type, x) snatch::impl::expression{type "(" #x ")", {}, false} <= x
+
+// Public test macros.
+// -------------------
 
 #define SNATCH_TEST_CASE(NAME, TAGS)                                                               \
     static const char* SNATCH_MACRO_CONCAT(test_id_, __COUNTER__) =                                \

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -940,6 +940,8 @@ struct with_what_contains : private contains_substring {
 
 #define SNATCH_CONCAT_IMPL(x, y) x##y
 #define SNATCH_MACRO_CONCAT(x, y) SNATCH_CONCAT_IMPL(x, y)
+#define SNATCH_MACRO_DISPATCH2(_1, _2, NAME, ...) NAME
+
 #define SNATCH_EXPR(type, x) snatch::impl::expression{type "(" #x ")", {}, false} <= x
 
 #define SNATCH_TEST_CASE(NAME, TAGS)                                                               \
@@ -954,9 +956,16 @@ struct with_what_contains : private contains_substring {
             snatch::impl::test_case & SNATCH_CURRENT_CASE [[maybe_unused]],                        \
             snatch::impl::section_state & SNATCH_SECTION_STATE [[maybe_unused]]) -> void
 
-#define SNATCH_SECTION(NAME, DESCRIPTION)                                                          \
+#define SNATCH_SECTION1(NAME)                                                                      \
+    if (snatch::impl::section_entry_checker SNATCH_MACRO_CONCAT(section_id_, __COUNTER__){         \
+            {(NAME), {}}, SNATCH_SECTION_STATE})
+
+#define SNATCH_SECTION2(NAME, DESCRIPTION)                                                         \
     if (snatch::impl::section_entry_checker SNATCH_MACRO_CONCAT(section_id_, __COUNTER__){         \
             {(NAME), (DESCRIPTION)}, SNATCH_SECTION_STATE})
+
+#define SNATCH_SECTION(...)                                                                        \
+    SNATCH_MACRO_DISPATCH2(__VA_ARGS__, SNATCH_SECTION2, SNATCH_SECTION1)(__VA_ARGS__)
 
 #define SNATCH_REQUIRE(EXP)                                                                        \
     do {                                                                                           \
@@ -1011,7 +1020,7 @@ struct with_what_contains : private contains_substring {
 #if SNATCH_WITH_SHORTHAND_MACROS
 #    define TEST_CASE(NAME, TAGS)                      SNATCH_TEST_CASE(NAME, TAGS)
 #    define TEMPLATE_LIST_TEST_CASE(NAME, TAGS, TYPES) SNATCH_TEMPLATE_LIST_TEST_CASE(NAME, TAGS, TYPES)
-#    define SECTION(NAME)                              SNATCH_SECTION(NAME)
+#    define SECTION(...)                               SNATCH_SECTION(__VA_ARGS__)
 #    define REQUIRE(EXP)                               SNATCH_REQUIRE(EXP)
 #    define CHECK(EXP)                                 SNATCH_CHECK(EXP)
 #    define FAIL(MESSAGE)                              SNATCH_FAIL(MESSAGE)

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -450,8 +450,8 @@ public:
 // -------------------------------
 
 namespace snatch {
-using small_string_span       = small_vector_span<char>;
-using small_string_const_span = small_vector_span<const char>;
+using small_string_span = small_vector_span<char>;
+using small_string_view = small_vector_span<const char>;
 
 template<std::size_t MaxLength>
 class small_string {
@@ -536,13 +536,13 @@ public:
     constexpr small_string_span span() noexcept {
         return small_string_span(data_buffer.data(), MaxLength, &data_size);
     }
-    constexpr small_string_const_span span() const noexcept {
-        return small_string_const_span(data_buffer.data(), MaxLength, &data_size);
+    constexpr small_string_view span() const noexcept {
+        return small_string_view(data_buffer.data(), MaxLength, &data_size);
     }
     constexpr operator small_string_span() noexcept {
         return span();
     }
-    constexpr operator small_string_const_span() const noexcept {
+    constexpr operator small_string_view() const noexcept {
         return span();
     }
     constexpr operator std::string_view() const noexcept {

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -756,7 +756,7 @@ struct section_entry_checker {
     section_state& state;
     bool           entered = false;
 
-    ~section_entry_checker();
+    ~section_entry_checker() noexcept;
 
     explicit operator bool() noexcept;
 };

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -1,16 +1,6 @@
 #ifndef SNATCH_HPP
 #define SNATCH_HPP
 
-#include <array> // for small_vector
-#include <cstddef> // for std::size_t
-#include <exception> // for std::exception
-#include <initializer_list> // for std::initializer_list
-#include <optional> // for cli
-#include <string_view> // for all strings
-#include <tuple> // for typed tests
-#include <type_traits> // for std::is_nothrow_*
-#include <variant> // for events
-
 #if !defined(SNATCH_MAX_TEST_CASES)
 #    define SNATCH_MAX_TEST_CASES 5'000
 #endif
@@ -54,6 +44,18 @@
 #if !defined(SNATCH_WITH_SHORTHAND_MACROS)
 #    define SNATCH_WITH_SHORTHAND_MACROS 1
 #endif
+
+#include <array> // for small_vector
+#include <cstddef> // for std::size_t
+#if SNATCH_WITH_EXCEPTIONS
+#    include <exception> // for std::exception
+#endif
+#include <initializer_list> // for std::initializer_list
+#include <optional> // for cli
+#include <string_view> // for all strings
+#include <tuple> // for typed tests
+#include <type_traits> // for std::is_nothrow_*
+#include <variant> // for events
 
 // Testing framework configuration.
 // --------------------------------

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -1057,30 +1057,30 @@ struct with_what_contains : private contains_substring {
 #define SNATCH_REQUIRE(EXP)                                                                        \
     do {                                                                                           \
         ++SNATCH_CURRENT_CASE.asserts;                                                             \
-        SNATCH_WARNING_PUSH;                                                                       \
-        SNATCH_WARNING_DISABLE_PARENTHESES;                                                        \
-        SNATCH_WARNING_DISABLE_CONSTANT_COMPARISON;                                                \
+        SNATCH_WARNING_PUSH                                                                        \
+        SNATCH_WARNING_DISABLE_PARENTHESES                                                         \
+        SNATCH_WARNING_DISABLE_CONSTANT_COMPARISON                                                 \
         if (!(EXP)) {                                                                              \
             snatch::tests.report_failure(                                                          \
                 SNATCH_CURRENT_CASE, SNATCH_SECTION_STATE, {__FILE__, __LINE__},                   \
                 SNATCH_EXPR("REQUIRE", EXP));                                                      \
             SNATCH_TESTING_ABORT;                                                                  \
         }                                                                                          \
-        SNATCH_WARNING_POP;                                                                        \
+        SNATCH_WARNING_POP                                                                         \
     } while (0)
 
 #define SNATCH_CHECK(EXP)                                                                          \
     do {                                                                                           \
         ++SNATCH_CURRENT_CASE.asserts;                                                             \
-        SNATCH_WARNING_PUSH;                                                                       \
-        SNATCH_WARNING_DISABLE_PARENTHESES;                                                        \
-        SNATCH_WARNING_DISABLE_CONSTANT_COMPARISON;                                                \
+        SNATCH_WARNING_PUSH                                                                        \
+        SNATCH_WARNING_DISABLE_PARENTHESES                                                         \
+        SNATCH_WARNING_DISABLE_CONSTANT_COMPARISON                                                 \
         if (!(EXP)) {                                                                              \
             snatch::tests.report_failure(                                                          \
                 SNATCH_CURRENT_CASE, SNATCH_SECTION_STATE, {__FILE__, __LINE__},                   \
                 SNATCH_EXPR("CHECK", EXP));                                                        \
         }                                                                                          \
-        SNATCH_WARNING_POP;                                                                        \
+        SNATCH_WARNING_POP                                                                         \
     } while (0)
 
 #define SNATCH_FAIL(MESSAGE)                                                                       \

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -582,6 +582,16 @@ template<typename T, typename U, typename... Args>
 
 void truncate_end(small_string_span ss) noexcept;
 
+template<typename... Args>
+bool append_or_truncate(small_string_span ss, Args&&... args) noexcept {
+    if (!append(ss, std::forward<Args>(args)...)) {
+        truncate_end(ss);
+        return false;
+    }
+
+    return true;
+}
+
 [[nodiscard]] bool replace_all(
     small_string_span string, std::string_view pattern, std::string_view replacement) noexcept;
 } // namespace snatch
@@ -858,10 +868,7 @@ public:
     template<typename... Args>
     void print(Args&&... args) const noexcept {
         small_string<max_message_length> message;
-        if (!append(message, std::forward<Args>(args)...)) {
-            truncate_end(message);
-        }
-
+        append_or_truncate(message, std::forward<Args>(args)...);
         this->print_callback(message);
     }
 

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -655,11 +655,16 @@ void stdout_print(std::string_view message) noexcept;
 
 struct abort_exception {};
 
+struct section_id {
+    std::string_view name;
+    std::string_view description;
+};
+
 struct section_nesting_level {
-    std::string_view current_section_name;
-    std::size_t      current_section_id  = 0;
-    std::size_t      previous_section_id = 0;
-    std::size_t      max_section_id      = 0;
+    section_id  current_section;
+    std::size_t current_section_id  = 0;
+    std::size_t previous_section_id = 0;
+    std::size_t max_section_id      = 0;
 };
 
 struct section_state {
@@ -669,9 +674,9 @@ struct section_state {
 };
 
 struct section_entry_checker {
-    std::string_view name;
-    section_state&   state;
-    bool             entered = false;
+    section_id     section;
+    section_state& state;
+    bool           entered = false;
 
     ~section_entry_checker();
 
@@ -949,9 +954,9 @@ struct with_what_contains : private contains_substring {
             snatch::impl::test_case & SNATCH_CURRENT_CASE [[maybe_unused]],                        \
             snatch::impl::section_state & SNATCH_SECTION_STATE [[maybe_unused]]) -> void
 
-#define SNATCH_SECTION(NAME)                                                                       \
+#define SNATCH_SECTION(NAME, DESCRIPTION)                                                          \
     if (snatch::impl::section_entry_checker SNATCH_MACRO_CONCAT(section_id_, __COUNTER__){         \
-            (NAME), SNATCH_SECTION_STATE})
+            {(NAME), (DESCRIPTION)}, SNATCH_SECTION_STATE})
 
 #define SNATCH_REQUIRE(EXP)                                                                        \
     do {                                                                                           \

--- a/include/snatch/snatch_teamcity.hpp
+++ b/include/snatch/snatch_teamcity.hpp
@@ -32,13 +32,9 @@ void send_message(
 small_string<max_test_name_length> make_full_name(const test_id& id) noexcept {
     small_string<max_test_name_length> name;
     if (id.type.length() != 0) {
-        if (!append(name, id.name, "(\"", id.type, "\")")) {
-            truncate_end(name);
-        }
+        append_or_truncate(name, id.name, "(\"", id.type, "\")");
     } else {
-        if (!append(name, id.name)) {
-            truncate_end(name);
-        }
+        append_or_truncate(name, id.name);
     }
 
     escape(name);
@@ -58,20 +54,16 @@ make_full_message(const snatch::assertion_location& location, std::string_view m
 
 small_string<max_message_length> make_escaped(std::string_view string) noexcept {
     small_string<max_message_length> escaped_string;
-    if (!append(escaped_string, string)) {
-        truncate_end(escaped_string);
-    }
-
+    append_or_truncate(escaped_string, string);
     escape(escaped_string);
     return escaped_string;
 }
 
-small_string<32> make_duration(float duration) noexcept {
-    small_string<32> string;
-    if (!append(string, static_cast<std::size_t>(duration * 1e6))) {
-        truncate_end(string);
-    }
+constexpr std::size_t max_duration_length = 32;
 
+small_string<max_duration_length> make_duration(float duration) noexcept {
+    small_string<max_duration_length> string;
+    append_or_truncate(string, static_cast<std::size_t>(duration * 1e6));
     return string;
 }
 

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -220,10 +220,7 @@ bool append(small_string_span ss, const colored<T>& colored_value) noexcept {
 template<typename... Args>
 void console_print(Args&&... args) noexcept {
     small_string<max_message_length> message;
-    if (!append(message, std::forward<Args>(args)...)) {
-        truncate_end(message);
-    }
-
+    append_or_truncate(message, std::forward<Args>(args)...);
     stdout_print(message);
 }
 
@@ -307,11 +304,8 @@ bool contains_substring::match(std::string_view message) const noexcept {
 
 std::string_view contains_substring::describe_fail(std::string_view message) const noexcept {
     description_buffer.clear();
-    if (!append(
-            description_buffer, "could not find '", substring_pattern, "' in '", message, "'")) {
-        truncate_end(description_buffer);
-    }
-
+    append_or_truncate(
+        description_buffer, "could not find '", substring_pattern, "' in '", message, "'");
     return description_buffer.str();
 }
 
@@ -534,9 +528,7 @@ void registry::report_failure(
     set_state(test, test_state::failed);
 
     small_string<max_message_length> message;
-    if (!append(message, message1, message2)) {
-        truncate_end(message);
-    }
+    append_or_truncate(message, message1, message2);
 
     if (!report_callback.empty()) {
         report_callback(
@@ -559,9 +551,7 @@ void registry::report_failure(
     if (!report_callback.empty()) {
         if (!exp.failed) {
             small_string<max_message_length> message;
-            if (!append(message, exp.content, ", got ", exp.data)) {
-                truncate_end(message);
-            }
+            append_or_truncate(message, exp.content, ", got ", exp.data);
             report_callback(
                 *this,
                 event::assertion_failed{test.id, sections.current_section, location, message});

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -240,6 +240,58 @@ namespace snatch {
 }
 } // namespace snatch
 
+// Sections implementation.
+// ------------------------
+
+namespace snatch::impl {
+section_entry_checker::~section_entry_checker() {
+    if (entered) {
+        if (state.levels.size() == state.depth) {
+            state.leaf_executed = true;
+        } else {
+            auto& child = state.levels[state.depth];
+            if (child.previous_section_id == child.max_section_id) {
+                state.levels.pop_back();
+            }
+        }
+    }
+
+    --state.depth;
+}
+
+section_entry_checker::operator bool() noexcept {
+    ++state.depth;
+
+    if (state.depth > state.levels.size()) {
+        if (state.depth > max_nested_sections) {
+            terminate_with("max number of nested sections reached; please increase "
+                           "SNATCH_MAX_NESTED_SECTIONS");
+        }
+
+        state.levels.push_back(section_nesting_level{});
+    }
+
+    auto& level = state.levels[state.depth - 1];
+
+    ++level.current_section_id;
+    if (level.max_section_id < level.current_section_id) {
+        level.max_section_id = level.current_section_id;
+    }
+
+    if (!state.leaf_executed && (level.previous_section_id + 1 == level.current_section_id ||
+                                 (level.previous_section_id == level.current_section_id &&
+                                  state.levels.size() > state.depth))) {
+
+        level.previous_section_id  = level.current_section_id;
+        level.current_section_name = name;
+        entered                    = true;
+        return true;
+    }
+
+    return false;
+}
+} // namespace snatch::impl
+
 // Matcher implementation.
 // -----------------------
 
@@ -408,12 +460,16 @@ void registry::register_test(const test_id& id, test_ptr func) noexcept {
 }
 
 void registry::print_location(
-    const impl::test_case& current_case, const assertion_location& location) const noexcept {
+    const impl::test_case&     current_case,
+    const impl::section_state& sections,
+    const assertion_location&  location) const noexcept {
 
     print(
         "running test case \"", make_colored(current_case.id.name, with_color, color::highlight1),
         "\"\n");
     print("          at ", location.file, ":", location.line, "\n");
+
+    // TODO: use 'sections' to print section info.
 
     if (!current_case.id.type.empty()) {
         print(
@@ -444,28 +500,31 @@ void registry::print_details_expr(const expression& exp) const noexcept {
 }
 
 void registry::report_failure(
-    impl::test_case&          t,
-    const assertion_location& location,
-    std::string_view          message) const noexcept {
+    impl::test_case&           test,
+    const impl::section_state& sections,
+    const assertion_location&  location,
+    std::string_view           message) const noexcept {
 
-    set_state(t, test_state::failed);
+    set_state(test, test_state::failed);
 
     if (!report_callback.empty()) {
-        report_callback(*this, event::assertion_failed{t.id, location, message});
+        // TODO: forward 'sections' to print section info, or convert to something nicer.
+        report_callback(*this, event::assertion_failed{test.id, location, message});
     } else {
         print_failure();
-        print_location(t, location);
+        print_location(test, sections, location);
         print_details(message);
     }
 }
 
 void registry::report_failure(
-    impl::test_case&          t,
-    const assertion_location& location,
-    std::string_view          message1,
-    std::string_view          message2) const noexcept {
+    impl::test_case&           test,
+    const impl::section_state& sections,
+    const assertion_location&  location,
+    std::string_view           message1,
+    std::string_view           message2) const noexcept {
 
-    set_state(t, test_state::failed);
+    set_state(test, test_state::failed);
 
     small_string<max_message_length> message;
     if (!append(message, message1, message2)) {
@@ -473,97 +532,119 @@ void registry::report_failure(
     }
 
     if (!report_callback.empty()) {
-        report_callback(*this, event::assertion_failed{t.id, location, message});
+        // TODO: forward 'sections' to print section info, or convert to something nicer.
+        report_callback(*this, event::assertion_failed{test.id, location, message});
     } else {
         print_failure();
-        print_location(t, location);
+        print_location(test, sections, location);
         print_details(message);
     }
 }
 
 void registry::report_failure(
-    impl::test_case&          t,
-    const assertion_location& location,
-    const impl::expression&   exp) const noexcept {
+    impl::test_case&           test,
+    const impl::section_state& sections,
+    const assertion_location&  location,
+    const impl::expression&    exp) const noexcept {
 
-    set_state(t, test_state::failed);
+    set_state(test, test_state::failed);
 
     if (!report_callback.empty()) {
+        // TODO: forward 'sections' to print section info, or convert to something nicer.
         if (!exp.failed) {
             small_string<max_message_length> message;
             if (!append(message, exp.content, ", got ", exp.data)) {
                 truncate_end(message);
             }
-            report_callback(*this, event::assertion_failed{t.id, location, message});
+            report_callback(*this, event::assertion_failed{test.id, location, message});
         } else {
-            report_callback(*this, event::assertion_failed{t.id, location, {exp.content}});
+            report_callback(*this, event::assertion_failed{test.id, location, {exp.content}});
         }
     } else {
         print_failure();
-        print_location(t, location);
+        print_location(test, sections, location);
         print_details_expr(exp);
     }
 }
 
 void registry::report_skipped(
-    impl::test_case&          t,
-    const assertion_location& location,
-    std::string_view          message) const noexcept {
+    impl::test_case&           test,
+    const impl::section_state& sections,
+    const assertion_location&  location,
+    std::string_view           message) const noexcept {
 
-    set_state(t, test_state::skipped);
+    set_state(test, test_state::skipped);
 
     if (!report_callback.empty()) {
-        report_callback(*this, event::test_case_skipped{t.id, location, message});
+        // TODO: forward 'sections' to print section info, or convert to something nicer.
+        report_callback(*this, event::test_case_skipped{test.id, location, message});
     } else {
         print_skip();
-        print_location(t, location);
+        print_location(test, sections, location);
         print_details(message);
     }
 }
 
-void registry::run(test_case& t) noexcept {
+void registry::run(test_case& test) noexcept {
     small_string<max_test_name_length> full_name;
 
     if (!report_callback.empty()) {
-        report_callback(*this, event::test_case_started{t.id});
+        report_callback(*this, event::test_case_started{test.id});
     } else if (is_at_least(verbose, verbosity::high)) {
-        make_full_name(full_name, t.id);
+        make_full_name(full_name, test.id);
         print(
             make_colored("starting:", with_color, color::status), " ",
             make_colored(full_name, with_color, color::highlight1), "\n");
     }
 
-    t.asserts = 0;
-    t.state   = test_state::success;
+    test.asserts = 0;
+    test.state   = test_state::success;
+
+    section_state sections;
 
     using clock     = std::chrono::high_resolution_clock;
     auto time_start = clock::now();
 
+    do {
+        for (auto& sections : sections.levels) {
+            sections.current_section_id   = 0;
+            sections.current_section_name = {};
+        }
+
+        sections.leaf_executed = false;
+
 #if SNATCH_WITH_EXCEPTIONS
-    try {
-        t.func(t);
-    } catch (const impl::abort_exception&) {
-        // Test aborted, assume its state was already set accordingly.
-    } catch (const std::exception& e) {
-        report_failure(
-            t, {__FILE__, __LINE__}, "unhandled std::exception caught; message:", e.what());
-    } catch (...) {
-        report_failure(t, {__FILE__, __LINE__}, "unhandled unknown exception caught");
-    }
+        try {
+            test.func(test, sections);
+        } catch (const impl::abort_exception&) {
+            // Test aborted, assume its state was already set accordingly.
+        } catch (const std::exception& e) {
+            report_failure(
+                test, {__FILE__, __LINE__}, "unhandled std::exception caught; message:", e.what());
+        } catch (...) {
+            report_failure(test, {__FILE__, __LINE__}, "unhandled unknown exception caught");
+        }
 #else
-    t.func(t);
+        test.func(test, sections);
 #endif
 
-    auto time_end = clock::now();
+        if (sections.levels.size() == 1) {
+            auto& child = sections.levels[0];
+            if (child.previous_section_id == child.max_section_id) {
+                sections.levels.clear();
+            }
+        }
+    } while (!sections.levels.empty());
 
-    t.duration = std::chrono::duration<float>(time_end - time_start).count();
+    auto time_end = clock::now();
+    test.duration = std::chrono::duration<float>(time_end - time_start).count();
 
     if (!report_callback.empty()) {
-        report_callback(*this, event::test_case_ended{t.id, t.duration});
+        report_callback(*this, event::test_case_ended{test.id, test.duration});
     } else if (is_at_least(verbose, verbosity::high)) {
         print(
             make_colored("finished:", with_color, color::status), " ",
-            make_colored(full_name, with_color, color::highlight1), " (", t.duration, "s)\n");
+            make_colored(full_name, with_color, color::highlight1), " (", test.duration, "s)\n");
     }
 }
 

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -241,7 +241,7 @@ namespace snatch {
 // ------------------------
 
 namespace snatch::impl {
-section_entry_checker::~section_entry_checker() {
+section_entry_checker::~section_entry_checker() noexcept {
     if (entered) {
         if (state.levels.size() == state.depth) {
             state.leaf_executed = true;

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -620,9 +620,11 @@ void registry::run(test_case& test) noexcept {
             // Test aborted, assume its state was already set accordingly.
         } catch (const std::exception& e) {
             report_failure(
-                test, {__FILE__, __LINE__}, "unhandled std::exception caught; message:", e.what());
+                test, sections, {__FILE__, __LINE__},
+                "unhandled std::exception caught; message:", e.what());
         } catch (...) {
-            report_failure(test, {__FILE__, __LINE__}, "unhandled unknown exception caught");
+            report_failure(
+                test, sections, {__FILE__, __LINE__}, "unhandled unknown exception caught");
         }
 #else
         test.func(test, sections);

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -282,9 +282,9 @@ section_entry_checker::operator bool() noexcept {
                                  (level.previous_section_id == level.current_section_id &&
                                   state.levels.size() > state.depth))) {
 
-        level.previous_section_id  = level.current_section_id;
-        level.current_section_name = name;
-        entered                    = true;
+        level.previous_section_id = level.current_section_id;
+        level.current_section     = section;
+        entered                   = true;
         return true;
     }
 
@@ -607,8 +607,8 @@ void registry::run(test_case& test) noexcept {
 
     do {
         for (auto& sections : sections.levels) {
-            sections.current_section_id   = 0;
-            sections.current_section_name = {};
+            sections.current_section_id = 0;
+            sections.current_section    = {};
         }
 
         sections.leaf_executed = false;


### PR DESCRIPTION
This PR does the following.

For #7:
 - Add `SECTION()` to nest test code and share set-up/tear-down logic, as in _Catch2_.
 - Modified the example Teamcity reporter to display section names in the error messages.

Other miscellaneous changes:
 - Added `pop_back()` to `small_vector.
 - Added immutable `small_vector_span<const T>` and `small_string_view`.
 - Do not include `<exception>` when exceptions are disabled.
 - Added `append_or_truncate()`.