### PR TITLE
Add `SNATCH_WITH_TIMINGS` plus bug fixes and performance improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,9 @@ set(SNATCH_MAX_TEST_NAME_LENGTH   1024 CACHE STRING "Maximum length of a test ca
 set(SNATCH_MAX_UNIQUE_TAGS        1024 CACHE STRING "Maximum number of unique tags in a test application.")
 set(SNATCH_MAX_COMMAND_LINE_ARGS  1024 CACHE STRING "Maximum number of command line arguments to a test application.")
 set(SNATCH_DEFINE_MAIN            ON   CACHE BOOL   "Define main() in snatch -- disable to provide your own main() function.")
-set(SNATCH_WITH_EXCEPTIONS        ON   CACHE BOOL   "Use exceptions in snatch implementation -- will be force OFF if exceptions are not available.")
+set(SNATCH_WITH_EXCEPTIONS        ON   CACHE BOOL   "Use exceptions in snatch implementation -- will be forced OFF if exceptions are not available.")
 set(SNATCH_WITH_SHORTHAND_MACROS  ON   CACHE BOOL   "Use short names for test macros -- disable if this causes conflicts.")
-set(SNATCH_DEFAULT_WITH_COLOR     ON   CACHE BOOL   "Enable terminal colors by default -- can also be controlled on command line.")
+set(SNATCH_DEFAULT_WITH_COLOR     ON   CACHE BOOL   "Enable terminal colors by default -- can also be controlled by command line interface.")
 
 add_library(snatch ${PROJECT_SOURCE_DIR}/src/snatch.cpp)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SNATCH_MAX_UNIQUE_TAGS        1024 CACHE STRING "Maximum number of unique ta
 set(SNATCH_MAX_COMMAND_LINE_ARGS  1024 CACHE STRING "Maximum number of command line arguments to a test application.")
 set(SNATCH_DEFINE_MAIN            ON   CACHE BOOL   "Define main() in snatch -- disable to provide your own main() function.")
 set(SNATCH_WITH_EXCEPTIONS        ON   CACHE BOOL   "Use exceptions in snatch implementation -- will be forced OFF if exceptions are not available.")
+set(SNATCH_WITH_TIMINGS           ON   CACHE BOOL   "Measure the time taken by each test case -- disable to speed up tests.")
 set(SNATCH_WITH_SHORTHAND_MACROS  ON   CACHE BOOL   "Use short names for test macros -- disable if this causes conflicts.")
 set(SNATCH_DEFAULT_WITH_COLOR     ON   CACHE BOOL   "Enable terminal colors by default -- can also be controlled by command line interface.")
 
@@ -33,6 +34,7 @@ target_compile_definitions(snatch PUBLIC
   SNATCH_MAX_COMMAND_LINE_ARGS=${SNATCH_MAX_COMMAND_LINE_ARGS}
   SNATCH_DEFINE_MAIN=$<BOOL:${SNATCH_DEFINE_MAIN}>
   SNATCH_WITH_EXCEPTIONS=$<BOOL:${SNATCH_WITH_EXCEPTIONS}>
+  SNATCH_WITH_TIMINGS=$<BOOL:${SNATCH_WITH_TIMINGS}>
   SNATCH_WITH_SHORTHAND_MACROS=$<BOOL:${SNATCH_WITH_SHORTHAND_MACROS}>
   SNATCH_DEFAULT_WITH_COLOR=$<BOOL:${SNATCH_DEFAULT_WITH_COLOR}>)
 

--- a/README.md
+++ b/README.md
@@ -116,11 +116,11 @@ Results for _snatch_:
 |                 | _snatch_ (Debug) | _snatch_ (Release) |
 |-----------------|------------------|--------------------|
 | Build framework | 1.6s             | 2.4s               |
-| Build tests     | 65s              | 133s               |
-| Build all       | 67s              | 135s               |
-| Run tests       | 15ms             | 8ms                |
-| Library size    | 2.70MB           | 0.68MB             |
-| Executable size | 29.9MB           | 8.8MB              |
+| Build tests     | 64s              | 130s               |
+| Build all       | 66s              | 132s               |
+| Run tests       | 13ms             | 8ms                |
+| Library size    | 2.60MB           | 0.60MB             |
+| Executable size | 29.2MB           | 8.6MB              |
 
 Results for alternative testing frameworks:
 

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -127,39 +127,6 @@ constexpr std::string_view get_type_name() noexcept {
 
     return function.substr(start, size);
 }
-
-template<typename T>
-struct proxy;
-
-template<typename... Args>
-struct proxy<std::tuple<Args...>> {
-    registry*        tests = nullptr;
-    std::string_view name;
-    std::string_view tags;
-
-    template<typename F>
-    const char* operator=(const F& func) noexcept;
-};
-
-struct test_case;
-struct section_state;
-
-using test_ptr = void (*)(test_case&, section_state&);
-
-template<typename T, typename F>
-constexpr test_ptr to_test_case_ptr(const F&) noexcept {
-    return [](test_case& t, section_state& s) { F{}.template operator()<T>(t, s); };
-}
-
-enum class test_state { not_run, success, skipped, failed };
-
-struct test_case {
-    test_id     id;
-    test_ptr    func     = nullptr;
-    test_state  state    = test_state::not_run;
-    std::size_t asserts  = 0;
-    float       duration = 0.0f;
-};
 } // namespace snatch::impl
 
 // Public utilities.
@@ -170,6 +137,8 @@ template<typename T>
 constexpr std::string_view type_name = impl::get_type_name<T>();
 
 [[noreturn]] void terminate_with(std::string_view msg) noexcept;
+
+struct registry;
 } // namespace snatch
 
 // Public utilities: small_vector.
@@ -683,6 +652,67 @@ public:
 // -----------------------
 
 namespace snatch::impl {
+template<typename T>
+struct proxy;
+
+template<typename... Args>
+struct proxy<std::tuple<Args...>> {
+    registry*        tests = nullptr;
+    std::string_view name;
+    std::string_view tags;
+
+    template<typename F>
+    const char* operator=(const F& func) noexcept;
+};
+
+struct test_run;
+
+using test_ptr = void (*)(test_run&);
+
+template<typename T, typename F>
+constexpr test_ptr to_test_case_ptr(const F&) noexcept {
+    return [](test_run& t) { F{}.template operator()<T>(t); };
+}
+
+enum class test_state { not_run, success, skipped, failed };
+
+struct test_case {
+    test_id     id;
+    test_ptr    func     = nullptr;
+    test_state  state    = test_state::not_run;
+    std::size_t asserts  = 0;
+    float       duration = 0.0f;
+};
+
+struct section_nesting_level {
+    std::size_t current_section_id  = 0;
+    std::size_t previous_section_id = 0;
+    std::size_t max_section_id      = 0;
+};
+
+struct section_state {
+    small_vector<section_id, max_nested_sections>            current_section;
+    small_vector<section_nesting_level, max_nested_sections> levels;
+    std::size_t                                              depth         = 0;
+    bool                                                     leaf_executed = false;
+};
+
+struct test_run {
+    registry&     reg;
+    test_case&    test;
+    section_state sections;
+};
+
+struct section_entry_checker {
+    section_id section;
+    test_run&  state;
+    bool       entered = false;
+
+    ~section_entry_checker() noexcept;
+
+    explicit operator bool() noexcept;
+};
+
 struct expression {
     std::string_view              content;
     small_string<max_expr_length> data;
@@ -737,29 +767,6 @@ struct expression {
 void stdout_print(std::string_view message) noexcept;
 
 struct abort_exception {};
-
-struct section_nesting_level {
-    std::size_t current_section_id  = 0;
-    std::size_t previous_section_id = 0;
-    std::size_t max_section_id      = 0;
-};
-
-struct section_state {
-    small_vector<section_id, max_nested_sections>            current_section;
-    small_vector<section_nesting_level, max_nested_sections> levels;
-    std::size_t                                              depth         = 0;
-    bool                                                     leaf_executed = false;
-};
-
-struct section_entry_checker {
-    section_id     section;
-    section_state& state;
-    bool           entered = false;
-
-    ~section_entry_checker() noexcept;
-
-    explicit operator bool() noexcept;
-};
 } // namespace snatch::impl
 
 // Sections.
@@ -892,29 +899,25 @@ public:
     }
 
     void report_failure(
-        impl::test_case&           test,
-        const impl::section_state& sections,
-        const assertion_location&  location,
-        std::string_view           message) const noexcept;
+        impl::test_run&           state,
+        const assertion_location& location,
+        std::string_view          message) const noexcept;
 
     void report_failure(
-        impl::test_case&           test,
-        const impl::section_state& sections,
-        const assertion_location&  location,
-        std::string_view           message1,
-        std::string_view           message2) const noexcept;
+        impl::test_run&           state,
+        const assertion_location& location,
+        std::string_view          message1,
+        std::string_view          message2) const noexcept;
 
     void report_failure(
-        impl::test_case&           test,
-        const impl::section_state& sections,
-        const assertion_location&  location,
-        const impl::expression&    exp) const noexcept;
+        impl::test_run&           state,
+        const assertion_location& location,
+        const impl::expression&   exp) const noexcept;
 
     void report_skipped(
-        impl::test_case&           test,
-        const impl::section_state& sections,
-        const assertion_location&  location,
-        std::string_view           message) const noexcept;
+        impl::test_run&           state,
+        const assertion_location& location,
+        std::string_view          message) const noexcept;
 
     void run(impl::test_case& test) noexcept;
 
@@ -1034,22 +1037,20 @@ struct with_what_contains : private contains_substring {
 #define SNATCH_TEST_CASE(NAME, TAGS)                                                               \
     static const char* SNATCH_MACRO_CONCAT(test_id_, __COUNTER__) =                                \
         snatch::tests.add(NAME, TAGS) =                                                            \
-            [](snatch::impl::test_case & SNATCH_CURRENT_CASE [[maybe_unused]],                     \
-               snatch::impl::section_state & SNATCH_SECTION_STATE [[maybe_unused]]) -> void
+            [](snatch::impl::test_run & SNATCH_CURRENT_TEST [[maybe_unused]]) -> void
 
 #define SNATCH_TEMPLATE_LIST_TEST_CASE(NAME, TAGS, TYPES)                                          \
     static const char* SNATCH_MACRO_CONCAT(test_id_, __COUNTER__) =                                \
         snatch::tests.add_with_types<TYPES>(NAME, TAGS) = []<typename TestType>(                   \
-            snatch::impl::test_case & SNATCH_CURRENT_CASE [[maybe_unused]],                        \
-            snatch::impl::section_state & SNATCH_SECTION_STATE [[maybe_unused]]) -> void
+            snatch::impl::test_run & SNATCH_CURRENT_TEST [[maybe_unused]]) -> void
 
 #define SNATCH_SECTION1(NAME)                                                                      \
     if (snatch::impl::section_entry_checker SNATCH_MACRO_CONCAT(section_id_, __COUNTER__){         \
-            {(NAME), {}}, SNATCH_SECTION_STATE})
+            {(NAME), {}}, SNATCH_CURRENT_TEST})
 
 #define SNATCH_SECTION2(NAME, DESCRIPTION)                                                         \
     if (snatch::impl::section_entry_checker SNATCH_MACRO_CONCAT(section_id_, __COUNTER__){         \
-            {(NAME), (DESCRIPTION)}, SNATCH_SECTION_STATE})
+            {(NAME), (DESCRIPTION)}, SNATCH_CURRENT_TEST})
 
 #define SNATCH_SECTION(...)                                                                        \
     SNATCH_MACRO_DISPATCH2(__VA_ARGS__, SNATCH_SECTION2, SNATCH_SECTION1)(__VA_ARGS__)
@@ -1062,8 +1063,7 @@ struct with_what_contains : private contains_substring {
         SNATCH_WARNING_DISABLE_CONSTANT_COMPARISON                                                 \
         if (!(EXP)) {                                                                              \
             snatch::tests.report_failure(                                                          \
-                SNATCH_CURRENT_CASE, SNATCH_SECTION_STATE, {__FILE__, __LINE__},                   \
-                SNATCH_EXPR("REQUIRE", EXP));                                                      \
+                SNATCH_CURRENT_TEST, {__FILE__, __LINE__}, SNATCH_EXPR("REQUIRE", EXP));           \
             SNATCH_TESTING_ABORT;                                                                  \
         }                                                                                          \
         SNATCH_WARNING_POP                                                                         \
@@ -1077,29 +1077,25 @@ struct with_what_contains : private contains_substring {
         SNATCH_WARNING_DISABLE_CONSTANT_COMPARISON                                                 \
         if (!(EXP)) {                                                                              \
             snatch::tests.report_failure(                                                          \
-                SNATCH_CURRENT_CASE, SNATCH_SECTION_STATE, {__FILE__, __LINE__},                   \
-                SNATCH_EXPR("CHECK", EXP));                                                        \
+                SNATCH_CURRENT_TEST, {__FILE__, __LINE__}, SNATCH_EXPR("CHECK", EXP));             \
         }                                                                                          \
         SNATCH_WARNING_POP                                                                         \
     } while (0)
 
 #define SNATCH_FAIL(MESSAGE)                                                                       \
     do {                                                                                           \
-        snatch::tests.report_failure(                                                              \
-            SNATCH_CURRENT_CASE, SNATCH_SECTION_STATE, {__FILE__, __LINE__}, (MESSAGE));           \
+        snatch::tests.report_failure(SNATCH_CURRENT_TEST, {__FILE__, __LINE__}, (MESSAGE));        \
         SNATCH_TESTING_ABORT;                                                                      \
     } while (0)
 
 #define SNATCH_FAIL_CHECK(MESSAGE)                                                                 \
     do {                                                                                           \
-        snatch::tests.report_failure(                                                              \
-            SNATCH_CURRENT_CASE, SNATCH_SECTION_STATE, {__FILE__, __LINE__}, (MESSAGE));           \
+        snatch::tests.report_failure(SNATCH_CURRENT_TEST, {__FILE__, __LINE__}, (MESSAGE));        \
     } while (0)
 
 #define SNATCH_SKIP(MESSAGE)                                                                       \
     do {                                                                                           \
-        snatch::tests.report_skipped(                                                              \
-            SNATCH_CURRENT_CASE, SNATCH_SECTION_STATE, {__FILE__, __LINE__}, (MESSAGE));           \
+        snatch::tests.report_skipped(SNATCH_CURRENT_TEST, {__FILE__, __LINE__}, (MESSAGE));        \
         SNATCH_TESTING_ABORT;                                                                      \
     } while (0)
 
@@ -1130,12 +1126,12 @@ struct with_what_contains : private contains_substring {
                     throw;                                                                         \
                 } catch (const std::exception& e) {                                                \
                     snatch::tests.report_failure(                                                  \
-                        SNATCH_CURRENT_CASE, SNATCH_SECTION_STATE, {__FILE__, __LINE__},           \
+                        SNATCH_CURRENT_TEST, {__FILE__, __LINE__},                                 \
                         #EXCEPTION " expected but other std::exception thrown; message: ",         \
                         e.what());                                                                 \
                 } catch (...) {                                                                    \
                     snatch::tests.report_failure(                                                  \
-                        SNATCH_CURRENT_CASE, SNATCH_SECTION_STATE, {__FILE__, __LINE__},           \
+                        SNATCH_CURRENT_TEST, {__FILE__, __LINE__},                                 \
                         #EXCEPTION " expected but other unknown exception thrown");                \
                 }                                                                                  \
                 SNATCH_TESTING_ABORT;                                                              \
@@ -1154,12 +1150,12 @@ struct with_what_contains : private contains_substring {
                     throw;                                                                         \
                 } catch (const std::exception& e) {                                                \
                     snatch::tests.report_failure(                                                  \
-                        SNATCH_CURRENT_CASE, SNATCH_SECTION_STATE, {__FILE__, __LINE__},           \
+                        SNATCH_CURRENT_TEST, {__FILE__, __LINE__},                                 \
                         #EXCEPTION " expected but other std::exception thrown; message: ",         \
                         e.what());                                                                 \
                 } catch (...) {                                                                    \
                     snatch::tests.report_failure(                                                  \
-                        SNATCH_CURRENT_CASE, SNATCH_SECTION_STATE, {__FILE__, __LINE__},           \
+                        SNATCH_CURRENT_TEST, {__FILE__, __LINE__},                                 \
                         #EXCEPTION " expected but other unknown exception thrown");                \
                 }                                                                                  \
             }                                                                                      \
@@ -1173,7 +1169,7 @@ struct with_what_contains : private contains_substring {
             } catch (const EXCEPTION& e) {                                                         \
                 if (!(MATCHER).match(e)) {                                                         \
                     snatch::tests.report_failure(                                                  \
-                        SNATCH_CURRENT_CASE, SNATCH_SECTION_STATE, {__FILE__, __LINE__},           \
+                        SNATCH_CURRENT_TEST, {__FILE__, __LINE__},                                 \
                         "could not match caught " #EXCEPTION " with expected content: ",           \
                         (MATCHER).describe_fail(e));                                               \
                     SNATCH_TESTING_ABORT;                                                          \
@@ -1183,12 +1179,12 @@ struct with_what_contains : private contains_substring {
                     throw;                                                                         \
                 } catch (const std::exception& e) {                                                \
                     snatch::tests.report_failure(                                                  \
-                        SNATCH_CURRENT_CASE, SNATCH_SECTION_STATE, {__FILE__, __LINE__},           \
+                        SNATCH_CURRENT_TEST, {__FILE__, __LINE__},                                 \
                         #EXCEPTION " expected but other std::exception thrown; message: ",         \
                         e.what());                                                                 \
                 } catch (...) {                                                                    \
                     snatch::tests.report_failure(                                                  \
-                        SNATCH_CURRENT_CASE, SNATCH_SECTION_STATE, {__FILE__, __LINE__},           \
+                        SNATCH_CURRENT_TEST, {__FILE__, __LINE__},                                 \
                         #EXCEPTION " expected but other unknown exception thrown");                \
                 }                                                                                  \
                 SNATCH_TESTING_ABORT;                                                              \
@@ -1203,7 +1199,7 @@ struct with_what_contains : private contains_substring {
             } catch (const EXCEPTION& e) {                                                         \
                 if (!(MATCHER).match(e)) {                                                         \
                     snatch::tests.report_failure(                                                  \
-                        SNATCH_CURRENT_CASE, SNATCH_SECTION_STATE, {__FILE__, __LINE__},           \
+                        SNATCH_CURRENT_TEST, {__FILE__, __LINE__},                                 \
                         "could not match caught " #EXCEPTION " with expected content: ",           \
                         (MATCHER).describe_fail(e));                                               \
                 }                                                                                  \
@@ -1212,12 +1208,12 @@ struct with_what_contains : private contains_substring {
                     throw;                                                                         \
                 } catch (const std::exception& e) {                                                \
                     snatch::tests.report_failure(                                                  \
-                        SNATCH_CURRENT_CASE, SNATCH_SECTION_STATE, {__FILE__, __LINE__},           \
+                        SNATCH_CURRENT_TEST, {__FILE__, __LINE__},                                 \
                         #EXCEPTION " expected but other std::exception thrown; message: ",         \
                         e.what());                                                                 \
                 } catch (...) {                                                                    \
                     snatch::tests.report_failure(                                                  \
-                        SNATCH_CURRENT_CASE, SNATCH_SECTION_STATE, {__FILE__, __LINE__},           \
+                        SNATCH_CURRENT_TEST, {__FILE__, __LINE__},                                 \
                         #EXCEPTION " expected but other unknown exception thrown");                \
                 }                                                                                  \
             }                                                                                      \

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -22,6 +22,18 @@
 #if !defined(SNATCH_MAX_COMMAND_LINE_ARGS)
 #    define SNATCH_MAX_COMMAND_LINE_ARGS 1'024
 #endif
+#if !defined(SNATCH_DEFINE_MAIN)
+#    define SNATCH_DEFINE_MAIN 1
+#endif
+#if !defined(SNATCH_WITH_EXCEPTIONS)
+#    define SNATCH_WITH_EXCEPTIONS 1
+#endif
+#if !defined(SNATCH_WITH_SHORTHAND_MACROS)
+#    define SNATCH_WITH_SHORTHAND_MACROS 1
+#endif
+#if !defined(SNATCH_DEFAULT_WITH_COLOR)
+#    define SNATCH_DEFAULT_WITH_COLOR 1
+#endif
 
 #if defined(_MSC_VER)
 #    if defined(_KERNEL_MODE) || (defined(_HAS_EXCEPTIONS) && !_HAS_EXCEPTIONS)
@@ -33,16 +45,9 @@
 #    endif
 #endif
 
-#if !defined(SNATCH_WITH_EXCEPTIONS)
-#    define SNATCH_WITH_EXCEPTIONS 1
-#endif
 #if defined(SNATCH_EXCEPTIONS_NOT_AVAILABLE)
 #    undef SNATCH_WITH_EXCEPTIONS
 #    define SNATCH_WITH_EXCEPTIONS 0
-#endif
-
-#if !defined(SNATCH_WITH_SHORTHAND_MACROS)
-#    define SNATCH_WITH_SHORTHAND_MACROS 1
 #endif
 
 #include <array> // for small_vector

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -28,6 +28,9 @@
 #if !defined(SNATCH_WITH_EXCEPTIONS)
 #    define SNATCH_WITH_EXCEPTIONS 1
 #endif
+#if !defined(SNATCH_WITH_TIMINGS)
+#    define SNATCH_WITH_TIMINGS 1
+#endif
 #if !defined(SNATCH_WITH_SHORTHAND_MACROS)
 #    define SNATCH_WITH_SHORTHAND_MACROS 1
 #endif
@@ -683,10 +686,12 @@ enum class test_state { not_run, success, skipped, failed };
 
 struct test_case {
     test_id     id;
-    test_ptr    func     = nullptr;
-    test_state  state    = test_state::not_run;
-    std::size_t asserts  = 0;
-    float       duration = 0.0f;
+    test_ptr    func    = nullptr;
+    test_state  state   = test_state::not_run;
+    std::size_t asserts = 0;
+#if SNATCH_WITH_TIMINGS
+    float duration = 0.0f;
+#endif
 };
 
 struct section_nesting_level {
@@ -805,7 +810,9 @@ struct test_case_started {
 
 struct test_case_ended {
     const test_id& id;
-    float          duration = 0.0f;
+#if SNATCH_WITH_TIMINGS
+    float duration = 0.0f;
+#endif
 };
 
 struct assertion_failed {

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -685,13 +685,9 @@ constexpr test_ptr to_test_case_ptr(const F&) noexcept {
 enum class test_state { not_run, success, skipped, failed };
 
 struct test_case {
-    test_id     id;
-    test_ptr    func    = nullptr;
-    test_state  state   = test_state::not_run;
-    std::size_t asserts = 0;
-#if SNATCH_WITH_TIMINGS
-    float duration = 0.0f;
-#endif
+    test_id    id;
+    test_ptr   func  = nullptr;
+    test_state state = test_state::not_run;
 };
 
 struct section_nesting_level {
@@ -711,6 +707,10 @@ struct test_run {
     registry&     reg;
     test_case&    test;
     section_state sections;
+    std::size_t   asserts = 0;
+#if SNATCH_WITH_TIMINGS
+    float duration = 0.0f;
+#endif
 };
 
 struct section_entry_checker {
@@ -931,7 +931,7 @@ public:
         const assertion_location& location,
         std::string_view          message) const noexcept;
 
-    void run(impl::test_case& test) noexcept;
+    impl::test_run run(impl::test_case& test) noexcept;
 
     bool run_all_tests(std::string_view run_name) noexcept;
     bool run_tests_matching_name(std::string_view run_name, std::string_view name_filter) noexcept;
@@ -1069,7 +1069,7 @@ struct with_what_contains : private contains_substring {
 
 #define SNATCH_REQUIRE(EXP)                                                                        \
     do {                                                                                           \
-        ++SNATCH_CURRENT_CASE.asserts;                                                             \
+        ++SNATCH_CURRENT_TEST.asserts;                                                             \
         SNATCH_WARNING_PUSH                                                                        \
         SNATCH_WARNING_DISABLE_PARENTHESES                                                         \
         SNATCH_WARNING_DISABLE_CONSTANT_COMPARISON                                                 \
@@ -1083,7 +1083,7 @@ struct with_what_contains : private contains_substring {
 
 #define SNATCH_CHECK(EXP)                                                                          \
     do {                                                                                           \
-        ++SNATCH_CURRENT_CASE.asserts;                                                             \
+        ++SNATCH_CURRENT_TEST.asserts;                                                             \
         SNATCH_WARNING_PUSH                                                                        \
         SNATCH_WARNING_DISABLE_PARENTHESES                                                         \
         SNATCH_WARNING_DISABLE_CONSTANT_COMPARISON                                                 \

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -1008,22 +1008,22 @@ struct with_what_contains : private contains_substring {
 #    define SNATCH_WARNING_PUSH _Pragma("clang diagnostic push")
 #    define SNATCH_WARNING_POP _Pragma("clang diagnostic pop")
 #    define SNATCH_WARNING_DISABLE_PARENTHESES _Pragma("clang diagnostic ignored \"-Wparentheses\"")
-#    define SNATCH_WARNING_DISABLE_CONSTANT_COMPARISON do {} while (0)
+#    define SNATCH_WARNING_DISABLE_CONSTANT_COMPARISON
 #elif defined(__GNUC__)
 #    define SNATCH_WARNING_PUSH _Pragma("GCC diagnostic push")
 #    define SNATCH_WARNING_POP _Pragma("GCC diagnostic pop")
 #    define SNATCH_WARNING_DISABLE_PARENTHESES _Pragma("GCC diagnostic ignored \"-Wparentheses\"")
-#    define SNATCH_WARNING_DISABLE_CONSTANT_COMPARISON do {} while (0)
+#    define SNATCH_WARNING_DISABLE_CONSTANT_COMPARISON
 #elif defined(_MSC_VER)
 #    define SNATCH_WARNING_PUSH _Pragma("warning(push)")
 #    define SNATCH_WARNING_POP _Pragma("warning(pop)")
-#    define SNATCH_WARNING_DISABLE_PARENTHESES do {} while (0)
+#    define SNATCH_WARNING_DISABLE_PARENTHESES
 #    define SNATCH_WARNING_DISABLE_CONSTANT_COMPARISON _Pragma("warning(disable: 4127)")
 #else
-#    define SNATCH_WARNING_PUSH do {} while (0)
-#    define SNATCH_WARNING_POP do {} while (0)
-#    define SNATCH_WARNING_DISABLE_PARENTHESES do {} while (0)
-#    define SNATCH_WARNING_DISABLE_CONSTANT_COMPARISON do {} while (0)
+#    define SNATCH_WARNING_PUSH
+#    define SNATCH_WARNING_POP
+#    define SNATCH_WARNING_DISABLE_PARENTHESES
+#    define SNATCH_WARNING_DISABLE_CONSTANT_COMPARISON
 #endif
 // clang-format on
 

--- a/include/snatch/snatch_teamcity.hpp
+++ b/include/snatch/snatch_teamcity.hpp
@@ -85,9 +85,13 @@ void report(const registry& r, const snatch::event::data& event) noexcept {
                 send_message(r, "testStarted", {{"name", make_full_name(e.id)}});
             },
             [&](const snatch::event::test_case_ended& e) {
+#if SNATCH_WITH_TIMINGS
                 send_message(
                     r, "testFinished",
                     {{"name", make_full_name(e.id)}, {"duration", make_duration(e.duration)}});
+#else
+                send_message(r, "testFinished", {{"name", make_full_name(e.id)}});
+#endif
             },
             [&](const snatch::event::test_case_skipped& e) {
                 send_message(

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -243,46 +243,51 @@ namespace snatch {
 namespace snatch::impl {
 section_entry_checker::~section_entry_checker() noexcept {
     if (entered) {
-        if (state.levels.size() == state.depth) {
-            state.leaf_executed = true;
+        if (state.sections.levels.size() == state.sections.depth) {
+            state.sections.leaf_executed = true;
         } else {
-            auto& child = state.levels[state.depth];
+            auto& child = state.sections.levels[state.sections.depth];
             if (child.previous_section_id == child.max_section_id) {
-                state.levels.pop_back();
+                state.sections.levels.pop_back();
             }
         }
 
-        state.current_section.pop_back();
+        state.sections.current_section.pop_back();
     }
 
-    --state.depth;
+    --state.sections.depth;
 }
 
 section_entry_checker::operator bool() noexcept {
-    ++state.depth;
+    ++state.sections.depth;
 
-    if (state.depth > state.levels.size()) {
-        if (state.depth > max_nested_sections) {
-            terminate_with("max number of nested sections reached; please increase "
-                           "SNATCH_MAX_NESTED_SECTIONS");
+    if (state.sections.depth > state.sections.levels.size()) {
+        if (state.sections.depth > max_nested_sections) {
+            state.reg.print(
+                make_colored("error:", state.reg.with_color, color::fail),
+                " max number of nested sections reached; "
+                "please increase 'SNATCH_MAX_NESTED_SECTIONS' (currently ",
+                max_nested_sections, ")\n.");
+            std::terminate();
         }
 
-        state.levels.push_back({});
+        state.sections.levels.push_back({});
     }
 
-    auto& level = state.levels[state.depth - 1];
+    auto& level = state.sections.levels[state.sections.depth - 1];
 
     ++level.current_section_id;
     if (level.max_section_id < level.current_section_id) {
         level.max_section_id = level.current_section_id;
     }
 
-    if (!state.leaf_executed && (level.previous_section_id + 1 == level.current_section_id ||
-                                 (level.previous_section_id == level.current_section_id &&
-                                  state.levels.size() > state.depth))) {
+    if (!state.sections.leaf_executed &&
+        (level.previous_section_id + 1 == level.current_section_id ||
+         (level.previous_section_id == level.current_section_id &&
+          state.sections.levels.size() > state.sections.depth))) {
 
         level.previous_section_id = level.current_section_id;
-        state.current_section.push_back(section);
+        state.sections.current_section.push_back(section);
         entered = true;
         return true;
     }
@@ -501,86 +506,85 @@ void registry::print_details_expr(const expression& exp) const noexcept {
 }
 
 void registry::report_failure(
-    impl::test_case&           test,
-    const impl::section_state& sections,
-    const assertion_location&  location,
-    std::string_view           message) const noexcept {
+    impl::test_run&           state,
+    const assertion_location& location,
+    std::string_view          message) const noexcept {
 
-    set_state(test, test_state::failed);
+    set_state(state.test, test_state::failed);
 
     if (!report_callback.empty()) {
         report_callback(
-            *this, event::assertion_failed{test.id, sections.current_section, location, message});
+            *this, event::assertion_failed{
+                       state.test.id, state.sections.current_section, location, message});
     } else {
         print_failure();
-        print_location(test, sections, location);
+        print_location(state.test, state.sections, location);
         print_details(message);
     }
 }
 
 void registry::report_failure(
-    impl::test_case&           test,
-    const impl::section_state& sections,
-    const assertion_location&  location,
-    std::string_view           message1,
-    std::string_view           message2) const noexcept {
+    impl::test_run&           state,
+    const assertion_location& location,
+    std::string_view          message1,
+    std::string_view          message2) const noexcept {
 
-    set_state(test, test_state::failed);
+    set_state(state.test, test_state::failed);
 
     small_string<max_message_length> message;
     append_or_truncate(message, message1, message2);
 
     if (!report_callback.empty()) {
         report_callback(
-            *this, event::assertion_failed{test.id, sections.current_section, location, message});
+            *this, event::assertion_failed{
+                       state.test.id, state.sections.current_section, location, message});
     } else {
         print_failure();
-        print_location(test, sections, location);
+        print_location(state.test, state.sections, location);
         print_details(message);
     }
 }
 
 void registry::report_failure(
-    impl::test_case&           test,
-    const impl::section_state& sections,
-    const assertion_location&  location,
-    const impl::expression&    exp) const noexcept {
+    impl::test_run&           state,
+    const assertion_location& location,
+    const impl::expression&   exp) const noexcept {
 
-    set_state(test, test_state::failed);
+    set_state(state.test, test_state::failed);
 
     if (!report_callback.empty()) {
         if (!exp.failed) {
             small_string<max_message_length> message;
             append_or_truncate(message, exp.content, ", got ", exp.data);
             report_callback(
-                *this,
-                event::assertion_failed{test.id, sections.current_section, location, message});
+                *this, event::assertion_failed{
+                           state.test.id, state.sections.current_section, location, message});
         } else {
             report_callback(
                 *this, event::assertion_failed{
-                           test.id, sections.current_section, location, {exp.content}});
+                           state.test.id, state.sections.current_section, location, {exp.content}});
         }
     } else {
         print_failure();
-        print_location(test, sections, location);
+        print_location(state.test, state.sections, location);
         print_details_expr(exp);
     }
 }
 
 void registry::report_skipped(
-    impl::test_case&           test,
-    const impl::section_state& sections,
-    const assertion_location&  location,
-    std::string_view           message) const noexcept {
+    impl::test_run&           state,
+    const assertion_location& location,
+    std::string_view          message) const noexcept {
 
-    set_state(test, test_state::skipped);
+    set_state(state.test, test_state::skipped);
 
     if (!report_callback.empty()) {
         report_callback(
-            *this, event::test_case_skipped{test.id, sections.current_section, location, message});
+            *this, event::test_case_skipped{
+                       state.test.id, state.sections.current_section, location, message});
     } else {
         print_skip();
-        print_location(test, sections, location);
+        print_location(state.test, state.sections, location);
         print_details(message);
     }
 }
@@ -600,43 +604,41 @@ void registry::run(test_case& test) noexcept {
     test.asserts = 0;
     test.state   = test_state::success;
 
-    section_state sections;
+    test_run state{.reg = *this, .test = test};
 
     using clock     = std::chrono::high_resolution_clock;
     auto time_start = clock::now();
 
     do {
-        for (std::size_t i = 0; i < sections.levels.size(); ++i) {
-            sections.levels[i].current_section_id = 0;
+        for (std::size_t i = 0; i < state.sections.levels.size(); ++i) {
+            state.sections.levels[i].current_section_id = 0;
         }
 
-        sections.leaf_executed = false;
+        state.sections.leaf_executed = false;
 
 #if SNATCH_WITH_EXCEPTIONS
         try {
-            test.func(test, sections);
+            test.func(state);
         } catch (const impl::abort_exception&) {
             // Test aborted, assume its state was already set accordingly.
         } catch (const std::exception& e) {
             report_failure(
-                test, sections, {__FILE__, __LINE__},
-                "unhandled std::exception caught; message:", e.what());
+                state, {__FILE__, __LINE__}, "unhandled std::exception caught; message:", e.what());
         } catch (...) {
-            report_failure(
-                test, sections, {__FILE__, __LINE__}, "unhandled unknown exception caught");
+            report_failure(state, {__FILE__, __LINE__}, "unhandled unknown exception caught");
         }
 #else
-        test.func(test, sections);
+        test.func(state);
 #endif
 
-        if (sections.levels.size() == 1) {
-            auto& child = sections.levels[0];
+        if (state.sections.levels.size() == 1) {
+            auto& child = state.sections.levels[0];
             if (child.previous_section_id == child.max_section_id) {
-                sections.levels.clear();
-                sections.current_section.clear();
+                state.sections.levels.clear();
+                state.sections.current_section.clear();
             }
         }
-    } while (!sections.levels.empty());
+    } while (!state.sections.levels.empty());
 
     auto time_end = clock::now();
     test.duration = std::chrono::duration<float>(time_end - time_start).count();

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -6,13 +6,6 @@
 #include <cstring> // for std::memcpy
 #include <optional> // for std::optional
 
-#if !defined(SNATCH_DEFINE_MAIN)
-#    define SNATCH_DEFINE_MAIN 1
-#endif
-#if !defined(SNATCH_WITH_COLOR)
-#    define SNATCH_WITH_COLOR 1
-#endif
-
 // Testing framework implementation utilities.
 // -------------------------------------------
 
@@ -1019,7 +1012,7 @@ const expected_arguments expected_args = {
     {{},                        {"test regex"},        "A regex to select which test cases (or tags) to run"}};
 // clang-format on
 
-constexpr bool with_color_default = SNATCH_WITH_COLOR == 1;
+constexpr bool with_color_default = SNATCH_DEFAULT_WITH_COLOR == 1;
 } // namespace
 
 namespace snatch::cli {


### PR DESCRIPTION
This PR does the following.

Bug fixes:
 - Fixed `SNATCH_DEFAULT_WITH_COLOR` not honored.
 - Fixed error message displayed when nesting sections too deep not using the usual format.
 - Fixed "missing semicolon" error in warning disabling macros when placeholders are used.

Miscellaneous changes:
 - Added `SNATCH_WITH_TIMINGS` to enable/disable test timing (enabled by default).
 - (internal) Moved all test state into a new struct `test_run`, instantiated when a test is run, rather than in the persistent `test_case`. This reduces binary size, results in minor speed up, and simplifies the code a bit.