### PR TITLE
Add `CAPTURE()` and `INFO()`

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: 'recursive'
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Setup Emscripten
       if: matrix.platform.compiler == 'em++'
-      uses: mymindstorm/setup-emsdk@v7
+      uses: mymindstorm/setup-emsdk@v11
       with:
         version: ${{env.EM_VERSION}}
         actions-cache-folder: ${{env.EM_CACHE_FOLDER}}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{github.workspace}}/build
-      run: ${{matrix.platform.cmakepp}} cmake .. -DCMAKE_BUILD_TYPE=${{matrix.build-type}} ${{matrix.platform.flags}} -DOUP_DO_TEST=1
+      run: ${{matrix.platform.cmakepp}} cmake .. -DCMAKE_BUILD_TYPE=${{matrix.build-type}} ${{matrix.platform.flags}}
 
     - name: Build
       shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ set(SNATCH_MAX_NESTED_SECTIONS    8    CACHE STRING "Maximum depth of nested sec
 set(SNATCH_MAX_EXPR_LENGTH        1024 CACHE STRING "Maximum length of a printed expression when reporting failure.")
 set(SNATCH_MAX_MESSAGE_LENGTH     1024 CACHE STRING "Maximum length of error or status messages.")
 set(SNATCH_MAX_TEST_NAME_LENGTH   1024 CACHE STRING "Maximum length of a test case name.")
+set(SNATCH_MAX_CAPTURES           8    CACHE STRING "Maximum number of captured expressions in a test case.")
+set(SNATCH_MAX_CAPTURE_LENGTH     256  CACHE STRING "Maximum length of a captured expression.")
 set(SNATCH_MAX_UNIQUE_TAGS        1024 CACHE STRING "Maximum number of unique tags in a test application.")
 set(SNATCH_MAX_COMMAND_LINE_ARGS  1024 CACHE STRING "Maximum number of command line arguments to a test application.")
 set(SNATCH_DEFINE_MAIN            ON   CACHE BOOL   "Define main() in snatch -- disable to provide your own main() function.")

--- a/README.md
+++ b/README.md
@@ -118,12 +118,12 @@ Results for _snatch_:
 
 |                 | _snatch_ (Debug) | _snatch_ (Release) |
 |-----------------|------------------|--------------------|
-| Build framework | 1.6s             | 2.4s               |
-| Build tests     | 64s              | 130s               |
-| Build all       | 66s              | 132s               |
-| Run tests       | 13ms             | 8ms                |
-| Library size    | 2.60MB           | 0.60MB             |
-| Executable size | 29.2MB           | 8.6MB              |
+| Build framework | 1.7s             | 2.5s               |
+| Build tests     | 64s              | 131s               |
+| Build all       | 65s              | 134s               |
+| Run tests       | 16ms             | 8ms                |
+| Library size    | 2.70MB           | 0.60MB             |
+| Executable size | 29.5MB           | 8.5MB              |
 
 Results for alternative testing frameworks:
 

--- a/README.md
+++ b/README.md
@@ -354,6 +354,8 @@ snatch::tests.report_callback = {reporter, snatch::constant<&Reporter::report>};
 
 If you need to use a reporter member function, please make sure that the reporter object remains alive for the duration of the tests (e.g., declare it static, global, or as a local variable declared in `main()`), or make sure to de-register it when your reporter is destroyed.
 
+Likewise, when receiving a test event, the event object will only contain non-owning references (e.g., in the form of string views) to the actual event data. These references are only valid until the report function returns, after which point the event data will be destroyed or overwritten. If you need persistent copies of this data, you must explicitly copy the data, and not the references. For example, for strings, this could involve creating a `std::string` (or `snatch::small_string`) from the `std::string_view` stored in the event object.
+
 An example reporter for _Teamcity_ is included for demonstration, see `include/snatch/snatch_teamcity.hpp`.
 
 

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -828,6 +828,13 @@ scoped_capture add_captures(test_run& state, std::string_view names, const Args&
     return {state.captures, sizeof...(args)};
 }
 
+template<string_appendable... Args>
+scoped_capture add_info(test_run& state, const Args&... args) noexcept {
+    auto& capture = add_capture(state);
+    append_or_truncate(capture, args...);
+    return {state.captures, 1};
+}
+
 void stdout_print(std::string_view message) noexcept;
 
 struct abort_exception {};
@@ -1129,6 +1136,10 @@ struct with_what_contains : private contains_substring {
     auto SNATCH_MACRO_CONCAT(capture_id_, __COUNTER__) =                                           \
         snatch::impl::add_captures(SNATCH_CURRENT_TEST, #__VA_ARGS__, __VA_ARGS__)
 
+#define SNATCH_INFO(...)                                                                           \
+    auto SNATCH_MACRO_CONCAT(capture_id_, __COUNTER__) =                                           \
+        snatch::impl::add_info(SNATCH_CURRENT_TEST, __VA_ARGS__)
+
 #define SNATCH_REQUIRE(EXP)                                                                        \
     do {                                                                                           \
         ++SNATCH_CURRENT_TEST.asserts;                                                             \
@@ -1179,6 +1190,7 @@ struct with_what_contains : private contains_substring {
 #    define TEMPLATE_LIST_TEST_CASE(NAME, TAGS, TYPES) SNATCH_TEMPLATE_LIST_TEST_CASE(NAME, TAGS, TYPES)
 #    define SECTION(...)                               SNATCH_SECTION(__VA_ARGS__)
 #    define CAPTURE(...)                               SNATCH_CAPTURE(__VA_ARGS__)
+#    define INFO(...)                                  SNATCH_INFO(__VA_ARGS__)
 #    define REQUIRE(EXP)                               SNATCH_REQUIRE(EXP)
 #    define CHECK(EXP)                                 SNATCH_CHECK(EXP)
 #    define FAIL(MESSAGE)                              SNATCH_FAIL(MESSAGE)

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -561,25 +561,34 @@ template<std::size_t N>
     return append(ss, std::string_view(str));
 }
 
-template<std::signed_integral T>
+template<typename T>
+concept signed_integral = std::is_signed_v<T>;
+
+template<typename T>
+concept unsigned_integral = std::is_unsigned_v<T>;
+
+template<typename T, typename U>
+concept convertible_to = std::is_convertible_v<T, U>;
+
+template<typename T>
+concept enumeration = std::is_enum_v<T>;
+
+template<signed_integral T>
 [[nodiscard]] bool append(small_string_span ss, T value) noexcept {
     return snatch::append(ss, static_cast<std::ptrdiff_t>(value));
 }
 
-template<std::unsigned_integral T>
+template<unsigned_integral T>
 [[nodiscard]] bool append(small_string_span ss, T value) noexcept {
     return snatch::append(ss, static_cast<std::size_t>(value));
 }
-
-template<typename T>
-concept enumeration = std::is_enum_v<T>;
 
 template<enumeration T>
 [[nodiscard]] bool append(small_string_span ss, T value) noexcept {
     return append(ss, static_cast<std::underlying_type_t<T>>(value));
 }
 
-template<std::convertible_to<std::string_view> T>
+template<convertible_to<std::string_view> T>
 [[nodiscard]] bool append(small_string_span ss, const T& value) noexcept {
     return snatch::append(ss, std::string_view(value));
 }

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -828,12 +828,13 @@ void stdout_print(std::string_view message) noexcept;
 struct abort_exception {};
 } // namespace snatch::impl
 
-// Sections.
+// Sections and captures.
 // ---------
 
 namespace snatch {
 using section_info = small_vector_span<const section_id>;
-}
+using capture_info = small_vector_span<const std::string_view>;
+} // namespace snatch
 
 // Events.
 // -------
@@ -867,6 +868,7 @@ struct test_case_ended {
 struct assertion_failed {
     const test_id&            id;
     section_info              sections;
+    capture_info              captures;
     const assertion_location& location;
     std::string_view          message;
 };
@@ -874,6 +876,7 @@ struct assertion_failed {
 struct test_case_skipped {
     const test_id&            id;
     section_info              sections;
+    capture_info              captures;
     const assertion_location& location;
     std::string_view          message;
 };

--- a/include/snatch/snatch_teamcity.hpp
+++ b/include/snatch/snatch_teamcity.hpp
@@ -44,12 +44,16 @@ small_string<max_test_name_length> make_full_name(const test_id& id) noexcept {
 small_string<max_message_length> make_full_message(
     const snatch::assertion_location& location,
     const snatch::section_info&       sections,
+    const snatch::capture_info&       captures,
     std::string_view                  message) noexcept {
 
     small_string<max_message_length> full_message;
     append_or_truncate(full_message, location.file, ":", location.line, "\n");
     for (const auto& s : sections) {
         append_or_truncate(full_message, s.name, "\n");
+    }
+    for (const auto& c : captures) {
+        append_or_truncate(full_message, c, "\n");
     }
 
     append_or_truncate(full_message, "  ", message);
@@ -97,13 +101,15 @@ void report(const registry& r, const snatch::event::data& event) noexcept {
                 send_message(
                     r, "testIgnored",
                     {{"name", make_full_name(e.id)},
-                     {"message", make_full_message(e.location, e.sections, e.message)}});
+                     {"message",
+                      make_full_message(e.location, e.sections, e.captures, e.message)}});
             },
             [&](const snatch::event::assertion_failed& e) {
                 send_message(
                     r, "testFailed",
                     {{"name", make_full_name(e.id)},
-                     {"message", make_full_message(e.location, e.sections, e.message)}});
+                     {"message",
+                      make_full_message(e.location, e.sections, e.captures, e.message)}});
             }},
         event);
 }

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -510,6 +510,15 @@ void set_state(test_case& t, test_state s) noexcept {
         t.state = s;
     }
 }
+
+small_vector<std::string_view, max_captures> make_capture_buffer(const capture_state& captures) {
+    small_vector<std::string_view, max_captures> captures_buffer;
+    for (const auto& c : captures) {
+        captures_buffer.push_back(c);
+    }
+
+    return captures_buffer;
+}
 } // namespace
 
 namespace snatch {
@@ -594,9 +603,11 @@ void registry::report_failure(
     set_state(state.test, test_state::failed);
 
     if (!report_callback.empty()) {
+        const auto captures_buffer = make_capture_buffer(state.captures);
         report_callback(
             *this, event::assertion_failed{
-                       state.test.id, state.sections.current_section, location, message});
+                       state.test.id, state.sections.current_section, captures_buffer.span(),
+                       location, message});
     } else {
         print_failure();
         print_location(state.test, state.sections, state.captures, location);
@@ -616,9 +627,11 @@ void registry::report_failure(
     append_or_truncate(message, message1, message2);
 
     if (!report_callback.empty()) {
+        const auto captures_buffer = make_capture_buffer(state.captures);
         report_callback(
             *this, event::assertion_failed{
-                       state.test.id, state.sections.current_section, location, message});
+                       state.test.id, state.sections.current_section, captures_buffer.span(),
+                       location, message});
     } else {
         print_failure();
         print_location(state.test, state.sections, state.captures, location);
@@ -634,16 +647,22 @@ void registry::report_failure(
     set_state(state.test, test_state::failed);
 
     if (!report_callback.empty()) {
+        const auto captures_buffer = make_capture_buffer(state.captures);
         if (!exp.failed) {
             small_string<max_message_length> message;
             append_or_truncate(message, exp.content, ", got ", exp.data);
             report_callback(
                 *this, event::assertion_failed{
-                           state.test.id, state.sections.current_section, location, message});
+                           state.test.id, state.sections.current_section, captures_buffer.span(),
+                           location, message});
         } else {
             report_callback(
                 *this, event::assertion_failed{
-                           state.test.id, state.sections.current_section, location, {exp.content}});
+                           state.test.id,
+                           state.sections.current_section,
+                           captures_buffer.span(),
+                           location,
+                           {exp.content}});
         }
     } else {
         print_failure();
@@ -660,9 +679,11 @@ void registry::report_skipped(
     set_state(state.test, test_state::skipped);
 
     if (!report_callback.empty()) {
+        const auto captures_buffer = make_capture_buffer(state.captures);
         report_callback(
             *this, event::test_case_skipped{
-                       state.test.id, state.sections.current_section, location, message});
+                       state.test.id, state.sections.current_section, captures_buffer.span(),
+                       location, message});
     } else {
         print_skip();
         print_location(state.test, state.sections, state.captures, location);


### PR DESCRIPTION
This PR does the following.

For #9.
 - Added `CAPTURE()` and `INFO()`.

Miscellaneous changes:
 - Clarify the way in which custom types can be made serializable, and added documentation to README.