### PR TITLE
Add more tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,8 +241,6 @@ namespace snatch::matchers {
 struct has_prefix {
     std::string_view prefix;
 
-    explicit has_prefix(std::string_view p) noexcept : prefix(p) {}
-
     bool match(std::string_view s) const noexcept {
         return s.starts_with(prefix) && s.size() >= prefix.size() + 1 && s[prefix.size()] == ':';
     }

--- a/README.md
+++ b/README.md
@@ -515,6 +515,15 @@ snatch::tests.report_callback = [](const snatch::registry& r, const snatch::even
     /* ... */
 };
 
+// Stateful lambda (with captures).
+// -------------------------------
+auto lambda = [&](const snatch::registry& r, const snatch::event::data& e) noexcept {
+    /* ... */
+};
+
+// 'lambda' must remain alive for the duration of the tests!
+snatch::tests.report_callback = lambda;
+
 // Member function (const or non-const, up to you).
 // ------------------------------------------------
 struct Reporter {

--- a/README.md
+++ b/README.md
@@ -441,20 +441,20 @@ failed: running test case "test with info"
 
 ### Custom string serialization
 
-When the _snatch_ framework needs to serialize a value to a string, it does so with the function `snatch::append(span, value)`, where `span` is a `snatch::small_string_span`, and `value` is the value to serialize. The function must return a boolean, equal to `true` if the serialization was successful, or `false` if there was not enough room in the output string to store the complete textual representation of the value. On failure, it is recommended to write as many characters as possible, and just truncate the output; this is what builtin functions do.
+When the _snatch_ framework needs to serialize a value to a string, it does so with the free function `append(span, value)`, where `span` is a `snatch::small_string_span`, and `value` is the value to serialize. The function must return a boolean, equal to `true` if the serialization was successful, or `false` if there was not enough room in the output string to store the complete textual representation of the value. On failure, it is recommended to write as many characters as possible, and just truncate the output; this is what builtin functions do.
 
 Builtin serialization functions are provided for all fundamental types: integers, enums (serialized as their underlying integer type), floating point, booleans, standard `string_view` and `char*`, and raw pointers.
 
-If you want to serialize custom types not supported out of the box by _snatch_, you need to provide your own overload of the `append()` function in the `snatch` namespace. In most cases, this function can be written in terms of serialization of fundamental types, and won't require low-level string manipulation. For example, to serialize a structure representing the 3D coordinates of a point:
+If you want to serialize custom types not supported out of the box by _snatch_, you need to provide your own `append()` function. This function must be placed in the same namespace as your custom type or in the `snatch` namespace, so it can be found by ADL. In most cases, this function can be written in terms of serialization of fundamental types, and won't require low-level string manipulation. For example, to serialize a structure representing the 3D coordinates of a point:
 
 ```c++
-struct vec3d {
-    float x;
-    float y;
-    float z;
-};
+namespace my_namespace {
+    struct vec3d {
+        float x;
+        float y;
+        float z;
+    };
 
-namespace snatch {
     bool append(small_string_span ss, const vec3d& v) {
         return append(ss, "{", v.x, ",", v.y, ",", v.z, "}");
     }
@@ -464,14 +464,14 @@ namespace snatch {
 Alternatively, to serialize a class with an existing `toString()` member:
 
 ```c++
-class MyClass {
-    // ...
+namespace my_namespace {
+    class MyClass {
+        // ...
 
-public:
-    std::string toString() const;
-};
+    public:
+        std::string toString() const;
+    };
 
-namespace snatch {
     bool append(small_string_span ss, const MyClass& c) {
         return append(ss, c.toString());
     }

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -1269,8 +1269,8 @@ struct is_any_of {
     describe_match(const T& value, match_status status) const noexcept {
         small_string<max_message_length> description_buffer;
         append_or_truncate(
-            description_buffer, "'", value, "' was ", (status == match_status::failed ? "not" : ""),
-            " found in {");
+            description_buffer, "'", value, "' was ",
+            (status == match_status::failed ? "not " : ""), "found in {");
 
         bool first = true;
         for (const auto& v : list) {

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -886,13 +886,13 @@ struct expression {
     small_string<max_expr_length> actual;
 
     template<string_appendable T>
-    [[nodiscard]] bool append(T&& value) noexcept {
-        return snatch::append(actual, std::forward<T>(value));
+    [[nodiscard]] bool append_value(T&& value) noexcept {
+        return append(actual, std::forward<T>(value));
     }
 
     template<typename T>
-    [[nodiscard]] bool append(T&&) noexcept {
-        return snatch::append(actual, "?");
+    [[nodiscard]] bool append_value(T&&) noexcept {
+        return append(actual, "?");
     }
 };
 
@@ -928,18 +928,19 @@ struct extracted_binary_expression {
                 using namespace snatch::matchers;
                 constexpr auto status = std::is_same_v<O, operator_equal> ? match_status::failed
                                                                           : match_status::matched;
-                if (!expr.append(lhs.describe_match(rhs, status))) {
+                if (!expr.append_value(lhs.describe_match(rhs, status))) {
                     expr.actual.clear();
                 }
             } else if constexpr (matcher_for<U, T>) {
                 using namespace snatch::matchers;
                 constexpr auto status = std::is_same_v<O, operator_equal> ? match_status::failed
                                                                           : match_status::matched;
-                if (!expr.append(rhs.describe_match(lhs, status))) {
+                if (!expr.append_value(rhs.describe_match(lhs, status))) {
                     expr.actual.clear();
                 }
             } else {
-                if (!expr.append(lhs) || !expr.append(O::inverse) || !expr.append(rhs)) {
+                if (!expr.append_value(lhs) || !expr.append_value(O::inverse) ||
+                    !expr.append_value(rhs)) {
                     expr.actual.clear();
                 }
             }
@@ -974,7 +975,7 @@ struct extracted_unary_expression {
 
     explicit operator bool() const noexcept {
         if (!static_cast<bool>(lhs)) {
-            if (!expr.append(lhs)) {
+            if (!expr.append_value(lhs)) {
                 expr.actual.clear();
             }
 

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -682,10 +682,10 @@ class small_function<Ret(Args...) noexcept> {
 public:
     constexpr small_function() = default;
 
-    constexpr small_function(function_ptr ptr) noexcept : data{ptr} {};
+    constexpr small_function(function_ptr ptr) noexcept : data{ptr} {}
 
     template<convertible_to<function_ptr> T>
-    constexpr small_function(T&& obj) noexcept : data{static_cast<function_ptr>(obj)} {};
+    constexpr small_function(T&& obj) noexcept : data{static_cast<function_ptr>(obj)} {}
 
     template<typename T, auto M>
     constexpr small_function(T& obj, constant<M>) noexcept :
@@ -696,7 +696,7 @@ public:
                 } else {
                     return (static_cast<T*>(ptr)->*constant<M>::value)(std::move(args)...);
                 }
-            }}} {};
+            }}} {}
 
     template<typename T, auto M>
     constexpr small_function(const T& obj, constant<M>) noexcept :
@@ -707,29 +707,14 @@ public:
                 } else {
                     return (static_cast<const T*>(ptr)->*constant<M>::value)(std::move(args)...);
                 }
-            }}} {};
+            }}} {}
 
     template<typename T>
-    constexpr small_function(T& obj) noexcept :
-        data{function_and_data_ptr{&obj, [](void* ptr, Args... args) noexcept {
-                                       if constexpr (std::is_same_v<Ret, void>) {
-                                           static_cast<T*>(ptr)->operator()(std::move(args)...);
-                                       } else {
-                                           return static_cast<T*>(ptr)->operator()(
-                                               std::move(args)...);
-                                       }
-                                   }}} {};
+    constexpr small_function(T& obj) noexcept : small_function(obj, constant<&T::operator()>{}) {}
 
     template<typename T>
     constexpr small_function(const T& obj) noexcept :
-        data{function_and_const_data_ptr{
-            &obj, [](const void* ptr, Args... args) noexcept {
-                if constexpr (std::is_same_v<Ret, void>) {
-                    static_cast<const T*>(ptr)->operator()(std::move(args)...);
-                } else {
-                    return static_cast<const T*>(ptr)->operator()(std::move(args)...);
-                }
-            }}} {};
+        small_function(obj, constant<&T::operator()>{}) {}
 
     // Prevent inadvertently using temporary stateful lambda; not supported at the moment.
     template<typename T>

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -684,6 +684,9 @@ public:
 
     constexpr small_function(function_ptr ptr) noexcept : data{ptr} {};
 
+    template<convertible_to<function_ptr> T>
+    constexpr small_function(T&& obj) noexcept : data{static_cast<function_ptr>(obj)} {};
+
     template<typename T, auto M>
     constexpr small_function(T& obj, constant<M>) noexcept :
         data{function_and_data_ptr{
@@ -705,6 +708,36 @@ public:
                     return (static_cast<const T*>(ptr)->*constant<M>::value)(std::move(args)...);
                 }
             }}} {};
+
+    template<typename T>
+    constexpr small_function(T& obj) noexcept :
+        data{function_and_data_ptr{&obj, [](void* ptr, Args... args) noexcept {
+                                       if constexpr (std::is_same_v<Ret, void>) {
+                                           static_cast<T*>(ptr)->operator()(std::move(args)...);
+                                       } else {
+                                           return static_cast<T*>(ptr)->operator()(
+                                               std::move(args)...);
+                                       }
+                                   }}} {};
+
+    template<typename T>
+    constexpr small_function(const T& obj) noexcept :
+        data{function_and_const_data_ptr{
+            &obj, [](const void* ptr, Args... args) noexcept {
+                if constexpr (std::is_same_v<Ret, void>) {
+                    static_cast<const T*>(ptr)->operator()(std::move(args)...);
+                } else {
+                    return static_cast<const T*>(ptr)->operator()(std::move(args)...);
+                }
+            }}} {};
+
+    // Prevent inadervently using temporary stateful lambda; not supported at the moment.
+    template<typename T>
+    constexpr small_function(T&& obj) noexcept = delete;
+
+    // Prevent inadervently using temporary object; not supported at the moment.
+    template<typename T, auto M>
+    constexpr small_function(T&& obj, constant<M>) noexcept = delete;
 
     template<typename... CArgs>
     constexpr Ret operator()(CArgs&&... args) const noexcept {

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -1380,7 +1380,7 @@ bool operator==(const M& m, const T& value) noexcept {
         SNATCH_WARNING_DISABLE_PARENTHESES                                                         \
         SNATCH_WARNING_DISABLE_CONSTANT_COMPARISON                                                 \
         if (SNATCH_EXPR("REQUIRE", EXP)) {                                                         \
-            snatch::tests.report_failure(                                                          \
+            SNATCH_CURRENT_TEST.reg.report_failure(                                                \
                 SNATCH_CURRENT_TEST, {__FILE__, __LINE__}, SNATCH_CURRENT_EXPRESSION);             \
             SNATCH_TESTING_ABORT;                                                                  \
         }                                                                                          \
@@ -1394,7 +1394,7 @@ bool operator==(const M& m, const T& value) noexcept {
         SNATCH_WARNING_DISABLE_PARENTHESES                                                         \
         SNATCH_WARNING_DISABLE_CONSTANT_COMPARISON                                                 \
         if (SNATCH_EXPR("CHECK", EXP)) {                                                           \
-            snatch::tests.report_failure(                                                          \
+            SNATCH_CURRENT_TEST.reg.report_failure(                                                \
                 SNATCH_CURRENT_TEST, {__FILE__, __LINE__}, SNATCH_CURRENT_EXPRESSION);             \
         }                                                                                          \
         SNATCH_WARNING_POP                                                                         \
@@ -1402,18 +1402,21 @@ bool operator==(const M& m, const T& value) noexcept {
 
 #define SNATCH_FAIL(MESSAGE)                                                                       \
     do {                                                                                           \
-        snatch::tests.report_failure(SNATCH_CURRENT_TEST, {__FILE__, __LINE__}, (MESSAGE));        \
+        SNATCH_CURRENT_TEST.reg.report_failure(                                                    \
+            SNATCH_CURRENT_TEST, {__FILE__, __LINE__}, (MESSAGE));                                 \
         SNATCH_TESTING_ABORT;                                                                      \
     } while (0)
 
 #define SNATCH_FAIL_CHECK(MESSAGE)                                                                 \
     do {                                                                                           \
-        snatch::tests.report_failure(SNATCH_CURRENT_TEST, {__FILE__, __LINE__}, (MESSAGE));        \
+        SNATCH_CURRENT_TEST.reg.report_failure(                                                    \
+            SNATCH_CURRENT_TEST, {__FILE__, __LINE__}, (MESSAGE));                                 \
     } while (0)
 
 #define SNATCH_SKIP(MESSAGE)                                                                       \
     do {                                                                                           \
-        snatch::tests.report_skipped(SNATCH_CURRENT_TEST, {__FILE__, __LINE__}, (MESSAGE));        \
+        SNATCH_CURRENT_TEST.reg.report_skipped(                                                    \
+            SNATCH_CURRENT_TEST, {__FILE__, __LINE__}, (MESSAGE));                                 \
         SNATCH_TESTING_ABORT;                                                                      \
     } while (0)
 
@@ -1466,12 +1469,12 @@ bool operator==(const M& m, const T& value) noexcept {
                 try {                                                                              \
                     throw;                                                                         \
                 } catch (const std::exception& e) {                                                \
-                    snatch::tests.report_failure(                                                  \
+                    SNATCH_CURRENT_TEST.reg.report_failure(                                        \
                         SNATCH_CURRENT_TEST, {__FILE__, __LINE__},                                 \
                         #EXCEPTION " expected but other std::exception thrown; message: ",         \
                         e.what());                                                                 \
                 } catch (...) {                                                                    \
-                    snatch::tests.report_failure(                                                  \
+                    SNATCH_CURRENT_TEST.reg.report_failure(                                        \
                         SNATCH_CURRENT_TEST, {__FILE__, __LINE__},                                 \
                         #EXCEPTION " expected but other unknown exception thrown");                \
                 }                                                                                  \
@@ -1490,12 +1493,12 @@ bool operator==(const M& m, const T& value) noexcept {
                 try {                                                                              \
                     throw;                                                                         \
                 } catch (const std::exception& e) {                                                \
-                    snatch::tests.report_failure(                                                  \
+                    SNATCH_CURRENT_TEST.reg.report_failure(                                        \
                         SNATCH_CURRENT_TEST, {__FILE__, __LINE__},                                 \
                         #EXCEPTION " expected but other std::exception thrown; message: ",         \
                         e.what());                                                                 \
                 } catch (...) {                                                                    \
-                    snatch::tests.report_failure(                                                  \
+                    SNATCH_CURRENT_TEST.reg.report_failure(                                        \
                         SNATCH_CURRENT_TEST, {__FILE__, __LINE__},                                 \
                         #EXCEPTION " expected but other unknown exception thrown");                \
                 }                                                                                  \
@@ -1509,7 +1512,7 @@ bool operator==(const M& m, const T& value) noexcept {
                 SNATCH_FAIL(#EXCEPTION " expected but no exception thrown");                       \
             } catch (const EXCEPTION& e) {                                                         \
                 if (!(MATCHER).match(e)) {                                                         \
-                    snatch::tests.report_failure(                                                  \
+                    SNATCH_CURRENT_TEST.reg.report_failure(                                        \
                         SNATCH_CURRENT_TEST, {__FILE__, __LINE__},                                 \
                         "could not match caught " #EXCEPTION " with expected content: ",           \
                         (MATCHER).describe_match(e, snatch::matchers::match_status::failed));      \
@@ -1519,12 +1522,12 @@ bool operator==(const M& m, const T& value) noexcept {
                 try {                                                                              \
                     throw;                                                                         \
                 } catch (const std::exception& e) {                                                \
-                    snatch::tests.report_failure(                                                  \
+                    SNATCH_CURRENT_TEST.reg.report_failure(                                        \
                         SNATCH_CURRENT_TEST, {__FILE__, __LINE__},                                 \
                         #EXCEPTION " expected but other std::exception thrown; message: ",         \
                         e.what());                                                                 \
                 } catch (...) {                                                                    \
-                    snatch::tests.report_failure(                                                  \
+                    SNATCH_CURRENT_TEST.reg.report_failure(                                        \
                         SNATCH_CURRENT_TEST, {__FILE__, __LINE__},                                 \
                         #EXCEPTION " expected but other unknown exception thrown");                \
                 }                                                                                  \
@@ -1539,7 +1542,7 @@ bool operator==(const M& m, const T& value) noexcept {
                 SNATCH_FAIL_CHECK(#EXCEPTION " expected but no exception thrown");                 \
             } catch (const EXCEPTION& e) {                                                         \
                 if (!(MATCHER).match(e)) {                                                         \
-                    snatch::tests.report_failure(                                                  \
+                    SNATCH_CURRENT_TEST.reg.report_failure(                                        \
                         SNATCH_CURRENT_TEST, {__FILE__, __LINE__},                                 \
                         "could not match caught " #EXCEPTION " with expected content: ",           \
                         (MATCHER).describe_match(e, snatch::matchers::match_status::failed));      \
@@ -1548,12 +1551,12 @@ bool operator==(const M& m, const T& value) noexcept {
                 try {                                                                              \
                     throw;                                                                         \
                 } catch (const std::exception& e) {                                                \
-                    snatch::tests.report_failure(                                                  \
+                    SNATCH_CURRENT_TEST.reg.report_failure(                                        \
                         SNATCH_CURRENT_TEST, {__FILE__, __LINE__},                                 \
                         #EXCEPTION " expected but other std::exception thrown; message: ",         \
                         e.what());                                                                 \
                 } catch (...) {                                                                    \
-                    snatch::tests.report_failure(                                                  \
+                    SNATCH_CURRENT_TEST.reg.report_failure(                                        \
                         SNATCH_CURRENT_TEST, {__FILE__, __LINE__},                                 \
                         #EXCEPTION " expected but other unknown exception thrown");                \
                 }                                                                                  \

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -1030,6 +1030,12 @@ scoped_capture add_info(test_run& state, const Args&... args) noexcept {
 void stdout_print(std::string_view message) noexcept;
 
 struct abort_exception {};
+
+template<typename T>
+concept exception_with_what = requires(const T& e) {
+    { e.what() }
+    ->convertible_to<std::string_view>;
+};
 } // namespace snatch::impl
 
 // Sections and captures.
@@ -1287,12 +1293,12 @@ is_any_of(T, Args...) -> is_any_of<T, sizeof...(Args) + 1>;
 struct with_what_contains : private contains_substring {
     explicit with_what_contains(std::string_view pattern) noexcept;
 
-    template<typename E>
+    template<snatch::impl::exception_with_what E>
     bool match(const E& e) const noexcept {
         return contains_substring::match(e.what());
     }
 
-    template<typename E>
+    template<snatch::impl::exception_with_what E>
     small_string<max_message_length>
     describe_match(const E& e, match_status status) const noexcept {
         return contains_substring::describe_match(e.what(), status);

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -731,11 +731,11 @@ public:
                 }
             }}} {};
 
-    // Prevent inadervently using temporary stateful lambda; not supported at the moment.
+    // Prevent inadvertently using temporary stateful lambda; not supported at the moment.
     template<typename T>
     constexpr small_function(T&& obj) noexcept = delete;
 
-    // Prevent inadervently using temporary object; not supported at the moment.
+    // Prevent inadvertently using temporary object; not supported at the moment.
     template<typename T, auto M>
     constexpr small_function(T&& obj, constant<M>) noexcept = delete;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,7 +45,8 @@ set(RUNTIME_TEST_FILES
   ${PROJECT_SOURCE_DIR}/tests/runtime_tests/small_string.cpp
   ${PROJECT_SOURCE_DIR}/tests/runtime_tests/string_utility.cpp
   ${PROJECT_SOURCE_DIR}/tests/runtime_tests/small_function.cpp
-  ${PROJECT_SOURCE_DIR}/tests/runtime_tests/matchers.cpp)
+  ${PROJECT_SOURCE_DIR}/tests/runtime_tests/matchers.cpp
+  ${PROJECT_SOURCE_DIR}/tests/runtime_tests/check.cpp)
 
 add_executable(snatch_runtime_tests ${RUNTIME_TEST_FILES})
 target_include_directories(snatch_runtime_tests PRIVATE ${PROJECT_SOURCE_DIR}/include)

--- a/tests/runtime_tests/check.cpp
+++ b/tests/runtime_tests/check.cpp
@@ -29,6 +29,20 @@ bool append(snatch::small_string_span ss, const non_relocatable& o) noexcept {
     return append(ss, "non_relocatable{", o.value, "}");
 }
 
+struct non_appendable {
+    int value = 0;
+
+    explicit non_appendable(int v) : value(v) {}
+
+    bool operator==(const non_appendable& other) const {
+        return this->value == other.value;
+    }
+
+    bool operator!=(const non_appendable& other) const {
+        return this->value != other.value;
+    }
+};
+
 struct event_deep_copy {
     enum class type { unknown, assertion_failed };
 
@@ -710,5 +724,23 @@ TEST_CASE("check misc", "[test macros]") {
         CHECK_EVENT_TEST_ID(event, mock_case.id);
         CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
         CHECK(event.message == "CHECK(non_relocatable(1) == non_relocatable(2)), got non_relocatable{1} != non_relocatable{2}"sv);
+    }
+
+    SECTION("non appendable fail") {
+#define SNATCH_CURRENT_TEST mock_run
+        // clang-format off
+        SNATCH_CHECK(non_appendable(1) == non_appendable(2)); const std::size_t failure_line = __LINE__;
+        // clang-foramt on
+#undef SNATCH_CURRENT_TEST
+
+        CHECK(mock_run.asserts == 1u);
+
+        REQUIRE(last_event.has_value());
+        const auto& event = last_event.value();
+        CHECK(event.event_type == event_deep_copy::type::assertion_failed);
+
+        CHECK_EVENT_TEST_ID(event, mock_case.id);
+        CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
+        CHECK(event.message == "CHECK(non_appendable(1) == non_appendable(2)), got ? != ?"sv);
     }
 };

--- a/tests/runtime_tests/check.cpp
+++ b/tests/runtime_tests/check.cpp
@@ -59,7 +59,7 @@ TEST_CASE("check", "[test macros]") {
 
     SECTION("unary") {
         SECTION("bool true") {
-            const bool value = true;
+            bool value = true;
 
 #define SNATCH_CURRENT_TEST mock_run
             SNATCH_CHECK(value);
@@ -71,7 +71,7 @@ TEST_CASE("check", "[test macros]") {
         }
 
         SECTION("bool false") {
-            const bool value = false;
+            bool value = false;
 
 #define SNATCH_CURRENT_TEST mock_run
             // clang-format off

--- a/tests/runtime_tests/check.cpp
+++ b/tests/runtime_tests/check.cpp
@@ -19,7 +19,7 @@ struct event_deep_copy {
 
 event_deep_copy deep_copy(const snatch::event::data& e) {
     return std::visit(
-        snatch::overload(
+        snatch::overload{
             [](const snatch::event::assertion_failed& a) {
                 event_deep_copy c;
                 c.event_type = event_deep_copy::type::assertion_failed;
@@ -31,7 +31,7 @@ event_deep_copy deep_copy(const snatch::event::data& e) {
                 append_or_truncate(c.message, a.message);
                 return c;
             },
-            [](const auto&) -> event_deep_copy { snatch::terminate_with("event not handled"); }),
+            [](const auto&) -> event_deep_copy { snatch::terminate_with("event not handled"); }},
         e);
 }
 

--- a/tests/runtime_tests/check.cpp
+++ b/tests/runtime_tests/check.cpp
@@ -743,4 +743,22 @@ TEST_CASE("check misc", "[test macros]") {
         CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
         CHECK(event.message == "CHECK(non_appendable(1) == non_appendable(2)), got ? != ?"sv);
     }
+
+    SECTION("matcher fail") {
+#define SNATCH_CURRENT_TEST mock_run
+        // clang-format off
+        SNATCH_CHECK("hello"sv == snatch::matchers::contains_substring{"foo"}); const std::size_t failure_line = __LINE__;
+        // clang-foramt on
+#undef SNATCH_CURRENT_TEST
+
+        CHECK(mock_run.asserts == 1u);
+
+        REQUIRE(last_event.has_value());
+        const auto& event = last_event.value();
+        CHECK(event.event_type == event_deep_copy::type::assertion_failed);
+
+        CHECK_EVENT_TEST_ID(event, mock_case.id);
+        CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
+        CHECK(event.message == "CHECK(\"hello\"sv == snatch::matchers::contains_substring{\"foo\"}), got could not find 'foo' in 'hello'"sv);
+    }
 };

--- a/tests/runtime_tests/check.cpp
+++ b/tests/runtime_tests/check.cpp
@@ -71,7 +71,7 @@ event_deep_copy deep_copy(const snatch::event::data& e) {
     CHECK(ACTUAL.location_file == std::string_view(FILE));                                         \
     CHECK(ACTUAL.location_line == LINE)
 
-TEST_CASE("check", "[test macros]") {
+TEST_CASE("check unary", "[test macros]") {
     snatch::registry mock_registry;
 
     snatch::impl::test_case mock_case{
@@ -93,528 +93,570 @@ TEST_CASE("check", "[test macros]") {
 
     mock_registry.report_callback = report;
 
-    SECTION("unary") {
-        SECTION("bool true") {
-            bool value = true;
+    SECTION("bool true") {
+        bool value = true;
 
 #define SNATCH_CURRENT_TEST mock_run
-            SNATCH_CHECK(value);
+        SNATCH_CHECK(value);
 #undef SNATCH_CURRENT_TEST
 
-            CHECK(value == true);
-            CHECK(mock_run.asserts == 1u);
-            CHECK(!last_event.has_value());
-        }
-
-        SECTION("bool false") {
-            bool value = false;
-
-#define SNATCH_CURRENT_TEST mock_run
-            // clang-format off
-            SNATCH_CHECK(value); const std::size_t failure_line = __LINE__;
-            // clang-format on
-#undef SNATCH_CURRENT_TEST
-
-            CHECK(value == false);
-            CHECK(mock_run.asserts == 1u);
-
-            REQUIRE(last_event.has_value());
-            const auto& event = last_event.value();
-            CHECK(event.event_type == event_deep_copy::type::assertion_failed);
-
-            CHECK_EVENT_TEST_ID(event, mock_case.id);
-            CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
-            CHECK(event.message == "CHECK(value), got false"sv);
-        }
-
-        SECTION("bool !true") {
-            bool value = true;
-
-#define SNATCH_CURRENT_TEST mock_run
-            // clang-format off
-            SNATCH_CHECK(!value); const std::size_t failure_line = __LINE__;
-            // clang-format on
-#undef SNATCH_CURRENT_TEST
-
-            CHECK(value == true);
-            CHECK(mock_run.asserts == 1u);
-
-            REQUIRE(last_event.has_value());
-            const auto& event = last_event.value();
-            CHECK(event.event_type == event_deep_copy::type::assertion_failed);
-
-            CHECK_EVENT_TEST_ID(event, mock_case.id);
-            CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
-            CHECK(event.message == "CHECK(!value), got false"sv);
-        }
-
-        SECTION("bool !false") {
-            bool value = false;
-
-#define SNATCH_CURRENT_TEST mock_run
-            SNATCH_CHECK(!value);
-#undef SNATCH_CURRENT_TEST
-
-            CHECK(value == false);
-            CHECK(mock_run.asserts == 1u);
-            CHECK(!last_event.has_value());
-        }
-
-        SECTION("integer non-zero") {
-            int value = 5;
-
-#define SNATCH_CURRENT_TEST mock_run
-            SNATCH_CHECK(value);
-#undef SNATCH_CURRENT_TEST
-
-            CHECK(value == 5);
-            CHECK(mock_run.asserts == 1u);
-            CHECK(!last_event.has_value());
-        }
-
-        SECTION("integer zero") {
-            int value = 0;
-
-#define SNATCH_CURRENT_TEST mock_run
-            // clang-format off
-            SNATCH_CHECK(value); const std::size_t failure_line = __LINE__;
-            // clang-format on
-#undef SNATCH_CURRENT_TEST
-
-            CHECK(value == 0);
-            CHECK(mock_run.asserts == 1u);
-
-            REQUIRE(last_event.has_value());
-            const auto& event = last_event.value();
-            CHECK(event.event_type == event_deep_copy::type::assertion_failed);
-
-            CHECK_EVENT_TEST_ID(event, mock_case.id);
-            CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
-            CHECK(event.message == "CHECK(value), got 0"sv);
-        }
-
-        SECTION("integer pre increment") {
-            int value = 0;
-
-#define SNATCH_CURRENT_TEST mock_run
-            SNATCH_CHECK(++value);
-#undef SNATCH_CURRENT_TEST
-
-            CHECK(value == 1);
-            CHECK(mock_run.asserts == 1u);
-            CHECK(!last_event.has_value());
-        }
-
-        SECTION("integer post increment") {
-            int value = 0;
-
-#define SNATCH_CURRENT_TEST mock_run
-            // clang-format off
-            SNATCH_CHECK(value++); const std::size_t failure_line = __LINE__;
-            // clang-format on
-#undef SNATCH_CURRENT_TEST
-
-            CHECK(value == 1);
-            CHECK(mock_run.asserts == 1u);
-
-            REQUIRE(last_event.has_value());
-            const auto& event = last_event.value();
-            CHECK(event.event_type == event_deep_copy::type::assertion_failed);
-
-            CHECK_EVENT_TEST_ID(event, mock_case.id);
-            CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
-            CHECK(event.message == "CHECK(value++), got 0"sv);
-        }
-
-        SECTION("integer expression * pass") {
-            int value = 1;
-
-#define SNATCH_CURRENT_TEST mock_run
-            SNATCH_CHECK(2 * value);
-#undef SNATCH_CURRENT_TEST
-
-            CHECK(value == 1);
-            CHECK(mock_run.asserts == 1u);
-            CHECK(!last_event.has_value());
-        }
-
-        SECTION("integer expression / pass") {
-            int value = 1;
-
-#define SNATCH_CURRENT_TEST mock_run
-            SNATCH_CHECK(2 / value);
-#undef SNATCH_CURRENT_TEST
-
-            CHECK(value == 1);
-            CHECK(mock_run.asserts == 1u);
-            CHECK(!last_event.has_value());
-        }
-
-        SECTION("integer expression + pass") {
-            int value = 1;
-
-#define SNATCH_CURRENT_TEST mock_run
-            SNATCH_CHECK(2 + value);
-#undef SNATCH_CURRENT_TEST
-
-            CHECK(value == 1);
-            CHECK(mock_run.asserts == 1u);
-            CHECK(!last_event.has_value());
-        }
-
-        SECTION("integer expression - pass") {
-            int value = 3;
-
-#define SNATCH_CURRENT_TEST mock_run
-            SNATCH_CHECK(2 - value);
-#undef SNATCH_CURRENT_TEST
-
-            CHECK(value == 3);
-            CHECK(mock_run.asserts == 1u);
-            CHECK(!last_event.has_value());
-        }
-
-        SECTION("integer expression % pass") {
-            int value = 3;
-
-#define SNATCH_CURRENT_TEST mock_run
-            SNATCH_CHECK(2 % value);
-#undef SNATCH_CURRENT_TEST
-
-            CHECK(value == 3);
-            CHECK(mock_run.asserts == 1u);
-            CHECK(!last_event.has_value());
-        }
-
-        SECTION("integer expression * fail") {
-            int value = 0;
-
-#define SNATCH_CURRENT_TEST mock_run
-            // clang-format off
-            SNATCH_CHECK(2 * value); const std::size_t failure_line = __LINE__;
-            // clang-format on
-#undef SNATCH_CURRENT_TEST
-
-            CHECK(value == 0);
-            CHECK(mock_run.asserts == 1u);
-
-            REQUIRE(last_event.has_value());
-            const auto& event = last_event.value();
-            CHECK(event.event_type == event_deep_copy::type::assertion_failed);
-
-            CHECK_EVENT_TEST_ID(event, mock_case.id);
-            CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
-            CHECK(event.message == "CHECK(2 * value), got 0"sv);
-        }
-
-        SECTION("integer expression / fail") {
-            int value = 5;
-
-#define SNATCH_CURRENT_TEST mock_run
-            // clang-format off
-            SNATCH_CHECK(2 / value); const std::size_t failure_line = __LINE__;
-            // clang-format on
-#undef SNATCH_CURRENT_TEST
-
-            CHECK(value == 5);
-            CHECK(mock_run.asserts == 1u);
-
-            REQUIRE(last_event.has_value());
-            const auto& event = last_event.value();
-            CHECK(event.event_type == event_deep_copy::type::assertion_failed);
-
-            CHECK_EVENT_TEST_ID(event, mock_case.id);
-            CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
-            CHECK(event.message == "CHECK(2 / value), got 0"sv);
-        }
-
-        SECTION("integer expression + fail") {
-            int value = -2;
-
-#define SNATCH_CURRENT_TEST mock_run
-            // clang-format off
-            SNATCH_CHECK(2 + value); const std::size_t failure_line = __LINE__;
-            // clang-format on
-#undef SNATCH_CURRENT_TEST
-
-            CHECK(value == -2);
-            CHECK(mock_run.asserts == 1u);
-
-            REQUIRE(last_event.has_value());
-            const auto& event = last_event.value();
-            CHECK(event.event_type == event_deep_copy::type::assertion_failed);
-
-            CHECK_EVENT_TEST_ID(event, mock_case.id);
-            CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
-            CHECK(event.message == "CHECK(2 + value), got 0"sv);
-        }
-
-        SECTION("integer expression - fail") {
-            int value = 2;
-
-#define SNATCH_CURRENT_TEST mock_run
-            // clang-format off
-            SNATCH_CHECK(2 - value); const std::size_t failure_line = __LINE__;
-            // clang-format on
-#undef SNATCH_CURRENT_TEST
-
-            CHECK(value == 2);
-            CHECK(mock_run.asserts == 1u);
-
-            REQUIRE(last_event.has_value());
-            const auto& event = last_event.value();
-            CHECK(event.event_type == event_deep_copy::type::assertion_failed);
-
-            CHECK_EVENT_TEST_ID(event, mock_case.id);
-            CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
-            CHECK(event.message == "CHECK(2 - value), got 0"sv);
-        }
-
-        SECTION("integer expression % fail") {
-            int value = 1;
-
-#define SNATCH_CURRENT_TEST mock_run
-            // clang-format off
-            SNATCH_CHECK(2 % value); const std::size_t failure_line = __LINE__;
-            // clang-format on
-#undef SNATCH_CURRENT_TEST
-
-            CHECK(value == 1);
-            CHECK(mock_run.asserts == 1u);
-
-            REQUIRE(last_event.has_value());
-            const auto& event = last_event.value();
-            CHECK(event.event_type == event_deep_copy::type::assertion_failed);
-
-            CHECK_EVENT_TEST_ID(event, mock_case.id);
-            CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
-            CHECK(event.message == "CHECK(2 % value), got 0"sv);
-        }
+        CHECK(value == true);
+        CHECK(mock_run.asserts == 1u);
+        CHECK(!last_event.has_value());
     }
 
-    SECTION("binary") {
-        SECTION("integer == pass") {
-            int value1 = 0;
-            int value2 = 0;
+    SECTION("bool false") {
+        bool value = false;
 
 #define SNATCH_CURRENT_TEST mock_run
-            SNATCH_CHECK(value1 == value2);
+        // clang-format off
+        SNATCH_CHECK(value); const std::size_t failure_line = __LINE__;
+        // clang-format on
 #undef SNATCH_CURRENT_TEST
 
-            CHECK(value1 == 0);
-            CHECK(value2 == 0);
-            CHECK(mock_run.asserts == 1u);
-            CHECK(!last_event.has_value());
-        }
+        CHECK(value == false);
+        CHECK(mock_run.asserts == 1u);
 
-        SECTION("integer != pass") {
-            int value1 = 0;
-            int value2 = 1;
+        REQUIRE(last_event.has_value());
+        const auto& event = last_event.value();
+        CHECK(event.event_type == event_deep_copy::type::assertion_failed);
 
-#define SNATCH_CURRENT_TEST mock_run
-            SNATCH_CHECK(value1 != value2);
-#undef SNATCH_CURRENT_TEST
-
-            CHECK(value1 == 0);
-            CHECK(value2 == 1);
-            CHECK(mock_run.asserts == 1u);
-            CHECK(!last_event.has_value());
-        }
-
-        SECTION("integer < pass") {
-            int value1 = 0;
-            int value2 = 1;
-
-#define SNATCH_CURRENT_TEST mock_run
-            SNATCH_CHECK(value1 < value2);
-#undef SNATCH_CURRENT_TEST
-
-            CHECK(value1 == 0);
-            CHECK(value2 == 1);
-            CHECK(mock_run.asserts == 1u);
-            CHECK(!last_event.has_value());
-        }
-
-        SECTION("integer > pass") {
-            int value1 = 1;
-            int value2 = 0;
-
-#define SNATCH_CURRENT_TEST mock_run
-            SNATCH_CHECK(value1 > value2);
-#undef SNATCH_CURRENT_TEST
-
-            CHECK(value1 == 1);
-            CHECK(value2 == 0);
-            CHECK(mock_run.asserts == 1u);
-            CHECK(!last_event.has_value());
-        }
-
-        SECTION("integer <= pass") {
-            int value1 = 0;
-            int value2 = 1;
-
-#define SNATCH_CURRENT_TEST mock_run
-            SNATCH_CHECK(value1 <= value2);
-#undef SNATCH_CURRENT_TEST
-
-            CHECK(value1 == 0);
-            CHECK(value2 == 1);
-            CHECK(mock_run.asserts == 1u);
-            CHECK(!last_event.has_value());
-        }
-
-        SECTION("integer >= pass") {
-            int value1 = 1;
-            int value2 = 0;
-
-#define SNATCH_CURRENT_TEST mock_run
-            SNATCH_CHECK(value1 >= value2);
-#undef SNATCH_CURRENT_TEST
-
-            CHECK(value1 == 1);
-            CHECK(value2 == 0);
-            CHECK(mock_run.asserts == 1u);
-            CHECK(!last_event.has_value());
-        }
-
-        SECTION("integer == fail") {
-            int value1 = 0;
-            int value2 = 1;
-
-#define SNATCH_CURRENT_TEST mock_run
-            // clang-format off
-            SNATCH_CHECK(value1 == value2); const std::size_t failure_line = __LINE__;
-            // clang-foramt on
-#undef SNATCH_CURRENT_TEST
-
-            CHECK(value1 == 0);
-            CHECK(value2 == 1);
-            CHECK(mock_run.asserts == 1u);
-
-            REQUIRE(last_event.has_value());
-            const auto& event = last_event.value();
-            CHECK(event.event_type == event_deep_copy::type::assertion_failed);
-
-            CHECK_EVENT_TEST_ID(event, mock_case.id);
-            CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
-            CHECK(event.message == "CHECK(value1 == value2), got 0 != 1"sv);
-        }
-
-        SECTION("integer != fail") {
-            int value1 = 0;
-            int value2 = 0;
-
-#define SNATCH_CURRENT_TEST mock_run
-            // clang-format off
-            SNATCH_CHECK(value1 != value2); const std::size_t failure_line = __LINE__;
-            // clang-foramt on
-#undef SNATCH_CURRENT_TEST
-
-            CHECK(value1 == 0);
-            CHECK(value2 == 0);
-            CHECK(mock_run.asserts == 1u);
-
-            REQUIRE(last_event.has_value());
-            const auto& event = last_event.value();
-            CHECK(event.event_type == event_deep_copy::type::assertion_failed);
-
-            CHECK_EVENT_TEST_ID(event, mock_case.id);
-            CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
-            CHECK(event.message == "CHECK(value1 != value2), got 0 == 0"sv);
-        }
-
-        SECTION("integer < fail") {
-            int value1 = 1;
-            int value2 = 0;
-
-#define SNATCH_CURRENT_TEST mock_run
-            // clang-format off
-            SNATCH_CHECK(value1 < value2); const std::size_t failure_line = __LINE__;
-            // clang-foramt on
-#undef SNATCH_CURRENT_TEST
-
-            CHECK(value1 == 1);
-            CHECK(value2 == 0);
-            CHECK(mock_run.asserts == 1u);
-
-            REQUIRE(last_event.has_value());
-            const auto& event = last_event.value();
-            CHECK(event.event_type == event_deep_copy::type::assertion_failed);
-
-            CHECK_EVENT_TEST_ID(event, mock_case.id);
-            CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
-            CHECK(event.message == "CHECK(value1 < value2), got 1 >= 0"sv);
-        }
-
-        SECTION("integer > fail") {
-            int value1 = 0;
-            int value2 = 1;
-
-#define SNATCH_CURRENT_TEST mock_run
-            // clang-format off
-            SNATCH_CHECK(value1 > value2); const std::size_t failure_line = __LINE__;
-            // clang-foramt on
-#undef SNATCH_CURRENT_TEST
-
-            CHECK(value1 == 0);
-            CHECK(value2 == 1);
-            CHECK(mock_run.asserts == 1u);
-
-            REQUIRE(last_event.has_value());
-            const auto& event = last_event.value();
-            CHECK(event.event_type == event_deep_copy::type::assertion_failed);
-
-            CHECK_EVENT_TEST_ID(event, mock_case.id);
-            CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
-            CHECK(event.message == "CHECK(value1 > value2), got 0 <= 1"sv);
-        }
-
-        SECTION("integer <= fail") {
-            int value1 = 1;
-            int value2 = 0;
-
-#define SNATCH_CURRENT_TEST mock_run
-            // clang-format off
-            SNATCH_CHECK(value1 <= value2); const std::size_t failure_line = __LINE__;
-            // clang-foramt on
-#undef SNATCH_CURRENT_TEST
-
-            CHECK(value1 == 1);
-            CHECK(value2 == 0);
-            CHECK(mock_run.asserts == 1u);
-
-            REQUIRE(last_event.has_value());
-            const auto& event = last_event.value();
-            CHECK(event.event_type == event_deep_copy::type::assertion_failed);
-
-            CHECK_EVENT_TEST_ID(event, mock_case.id);
-            CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
-            CHECK(event.message == "CHECK(value1 <= value2), got 1 > 0"sv);
-        }
-
-        SECTION("integer >= fail") {
-            int value1 = 0;
-            int value2 = 1;
-
-#define SNATCH_CURRENT_TEST mock_run
-            // clang-format off
-            SNATCH_CHECK(value1 >= value2); const std::size_t failure_line = __LINE__;
-            // clang-foramt on
-#undef SNATCH_CURRENT_TEST
-
-            CHECK(value1 == 0);
-            CHECK(value2 == 1);
-            CHECK(mock_run.asserts == 1u);
-
-            REQUIRE(last_event.has_value());
-            const auto& event = last_event.value();
-            CHECK(event.event_type == event_deep_copy::type::assertion_failed);
-
-            CHECK_EVENT_TEST_ID(event, mock_case.id);
-            CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
-            CHECK(event.message == "CHECK(value1 >= value2), got 0 < 1"sv);
-        }
+        CHECK_EVENT_TEST_ID(event, mock_case.id);
+        CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
+        CHECK(event.message == "CHECK(value), got false"sv);
     }
+
+    SECTION("bool !true") {
+        bool value = true;
+
+#define SNATCH_CURRENT_TEST mock_run
+        // clang-format off
+        SNATCH_CHECK(!value); const std::size_t failure_line = __LINE__;
+        // clang-format on
+#undef SNATCH_CURRENT_TEST
+
+        CHECK(value == true);
+        CHECK(mock_run.asserts == 1u);
+
+        REQUIRE(last_event.has_value());
+        const auto& event = last_event.value();
+        CHECK(event.event_type == event_deep_copy::type::assertion_failed);
+
+        CHECK_EVENT_TEST_ID(event, mock_case.id);
+        CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
+        CHECK(event.message == "CHECK(!value), got false"sv);
+    }
+
+    SECTION("bool !false") {
+        bool value = false;
+
+#define SNATCH_CURRENT_TEST mock_run
+        SNATCH_CHECK(!value);
+#undef SNATCH_CURRENT_TEST
+
+        CHECK(value == false);
+        CHECK(mock_run.asserts == 1u);
+        CHECK(!last_event.has_value());
+    }
+
+    SECTION("integer non-zero") {
+        int value = 5;
+
+#define SNATCH_CURRENT_TEST mock_run
+        SNATCH_CHECK(value);
+#undef SNATCH_CURRENT_TEST
+
+        CHECK(value == 5);
+        CHECK(mock_run.asserts == 1u);
+        CHECK(!last_event.has_value());
+    }
+
+    SECTION("integer zero") {
+        int value = 0;
+
+#define SNATCH_CURRENT_TEST mock_run
+        // clang-format off
+        SNATCH_CHECK(value); const std::size_t failure_line = __LINE__;
+        // clang-format on
+#undef SNATCH_CURRENT_TEST
+
+        CHECK(value == 0);
+        CHECK(mock_run.asserts == 1u);
+
+        REQUIRE(last_event.has_value());
+        const auto& event = last_event.value();
+        CHECK(event.event_type == event_deep_copy::type::assertion_failed);
+
+        CHECK_EVENT_TEST_ID(event, mock_case.id);
+        CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
+        CHECK(event.message == "CHECK(value), got 0"sv);
+    }
+
+    SECTION("integer pre increment") {
+        int value = 0;
+
+#define SNATCH_CURRENT_TEST mock_run
+        SNATCH_CHECK(++value);
+#undef SNATCH_CURRENT_TEST
+
+        CHECK(value == 1);
+        CHECK(mock_run.asserts == 1u);
+        CHECK(!last_event.has_value());
+    }
+
+    SECTION("integer post increment") {
+        int value = 0;
+
+#define SNATCH_CURRENT_TEST mock_run
+        // clang-format off
+        SNATCH_CHECK(value++); const std::size_t failure_line = __LINE__;
+        // clang-format on
+#undef SNATCH_CURRENT_TEST
+
+        CHECK(value == 1);
+        CHECK(mock_run.asserts == 1u);
+
+        REQUIRE(last_event.has_value());
+        const auto& event = last_event.value();
+        CHECK(event.event_type == event_deep_copy::type::assertion_failed);
+
+        CHECK_EVENT_TEST_ID(event, mock_case.id);
+        CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
+        CHECK(event.message == "CHECK(value++), got 0"sv);
+    }
+
+    SECTION("integer expression * pass") {
+        int value = 1;
+
+#define SNATCH_CURRENT_TEST mock_run
+        SNATCH_CHECK(2 * value);
+#undef SNATCH_CURRENT_TEST
+
+        CHECK(value == 1);
+        CHECK(mock_run.asserts == 1u);
+        CHECK(!last_event.has_value());
+    }
+
+    SECTION("integer expression / pass") {
+        int value = 1;
+
+#define SNATCH_CURRENT_TEST mock_run
+        SNATCH_CHECK(2 / value);
+#undef SNATCH_CURRENT_TEST
+
+        CHECK(value == 1);
+        CHECK(mock_run.asserts == 1u);
+        CHECK(!last_event.has_value());
+    }
+
+    SECTION("integer expression + pass") {
+        int value = 1;
+
+#define SNATCH_CURRENT_TEST mock_run
+        SNATCH_CHECK(2 + value);
+#undef SNATCH_CURRENT_TEST
+
+        CHECK(value == 1);
+        CHECK(mock_run.asserts == 1u);
+        CHECK(!last_event.has_value());
+    }
+
+    SECTION("integer expression - pass") {
+        int value = 3;
+
+#define SNATCH_CURRENT_TEST mock_run
+        SNATCH_CHECK(2 - value);
+#undef SNATCH_CURRENT_TEST
+
+        CHECK(value == 3);
+        CHECK(mock_run.asserts == 1u);
+        CHECK(!last_event.has_value());
+    }
+
+    SECTION("integer expression % pass") {
+        int value = 3;
+
+#define SNATCH_CURRENT_TEST mock_run
+        SNATCH_CHECK(2 % value);
+#undef SNATCH_CURRENT_TEST
+
+        CHECK(value == 3);
+        CHECK(mock_run.asserts == 1u);
+        CHECK(!last_event.has_value());
+    }
+
+    SECTION("integer expression * fail") {
+        int value = 0;
+
+#define SNATCH_CURRENT_TEST mock_run
+        // clang-format off
+        SNATCH_CHECK(2 * value); const std::size_t failure_line = __LINE__;
+        // clang-format on
+#undef SNATCH_CURRENT_TEST
+
+        CHECK(value == 0);
+        CHECK(mock_run.asserts == 1u);
+
+        REQUIRE(last_event.has_value());
+        const auto& event = last_event.value();
+        CHECK(event.event_type == event_deep_copy::type::assertion_failed);
+
+        CHECK_EVENT_TEST_ID(event, mock_case.id);
+        CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
+        CHECK(event.message == "CHECK(2 * value), got 0"sv);
+    }
+
+    SECTION("integer expression / fail") {
+        int value = 5;
+
+#define SNATCH_CURRENT_TEST mock_run
+        // clang-format off
+        SNATCH_CHECK(2 / value); const std::size_t failure_line = __LINE__;
+        // clang-format on
+#undef SNATCH_CURRENT_TEST
+
+        CHECK(value == 5);
+        CHECK(mock_run.asserts == 1u);
+
+        REQUIRE(last_event.has_value());
+        const auto& event = last_event.value();
+        CHECK(event.event_type == event_deep_copy::type::assertion_failed);
+
+        CHECK_EVENT_TEST_ID(event, mock_case.id);
+        CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
+        CHECK(event.message == "CHECK(2 / value), got 0"sv);
+    }
+
+    SECTION("integer expression + fail") {
+        int value = -2;
+
+#define SNATCH_CURRENT_TEST mock_run
+        // clang-format off
+        SNATCH_CHECK(2 + value); const std::size_t failure_line = __LINE__;
+        // clang-format on
+#undef SNATCH_CURRENT_TEST
+
+        CHECK(value == -2);
+        CHECK(mock_run.asserts == 1u);
+
+        REQUIRE(last_event.has_value());
+        const auto& event = last_event.value();
+        CHECK(event.event_type == event_deep_copy::type::assertion_failed);
+
+        CHECK_EVENT_TEST_ID(event, mock_case.id);
+        CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
+        CHECK(event.message == "CHECK(2 + value), got 0"sv);
+    }
+
+    SECTION("integer expression - fail") {
+        int value = 2;
+
+#define SNATCH_CURRENT_TEST mock_run
+        // clang-format off
+        SNATCH_CHECK(2 - value); const std::size_t failure_line = __LINE__;
+        // clang-format on
+#undef SNATCH_CURRENT_TEST
+
+        CHECK(value == 2);
+        CHECK(mock_run.asserts == 1u);
+
+        REQUIRE(last_event.has_value());
+        const auto& event = last_event.value();
+        CHECK(event.event_type == event_deep_copy::type::assertion_failed);
+
+        CHECK_EVENT_TEST_ID(event, mock_case.id);
+        CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
+        CHECK(event.message == "CHECK(2 - value), got 0"sv);
+    }
+
+    SECTION("integer expression % fail") {
+        int value = 1;
+
+#define SNATCH_CURRENT_TEST mock_run
+        // clang-format off
+        SNATCH_CHECK(2 % value); const std::size_t failure_line = __LINE__;
+        // clang-format on
+#undef SNATCH_CURRENT_TEST
+
+        CHECK(value == 1);
+        CHECK(mock_run.asserts == 1u);
+
+        REQUIRE(last_event.has_value());
+        const auto& event = last_event.value();
+        CHECK(event.event_type == event_deep_copy::type::assertion_failed);
+
+        CHECK_EVENT_TEST_ID(event, mock_case.id);
+        CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
+        CHECK(event.message == "CHECK(2 % value), got 0"sv);
+    }
+};
+
+TEST_CASE("check binary", "[test macros]") {
+    snatch::registry mock_registry;
+
+    snatch::impl::test_case mock_case{
+        .id    = {"mock_test", "[mock_tag]", "mock_type"},
+        .func  = nullptr,
+        .state = snatch::impl::test_state::not_run};
+
+    snatch::impl::test_run mock_run {
+        .reg = mock_registry, .test = mock_case, .sections = {}, .captures = {}, .asserts = 0,
+#if SNATCH_WITH_TIMINGS
+        .duration = 0.0f
+#endif
+    };
+
+    std::optional<event_deep_copy> last_event;
+    auto report = [&](const snatch::registry&, const snatch::event::data& e) noexcept {
+        last_event.emplace(deep_copy(e));
+    };
+
+    mock_registry.report_callback = report;
+
+    SECTION("integer == pass") {
+        int value1 = 0;
+        int value2 = 0;
+
+#define SNATCH_CURRENT_TEST mock_run
+        SNATCH_CHECK(value1 == value2);
+#undef SNATCH_CURRENT_TEST
+
+        CHECK(value1 == 0);
+        CHECK(value2 == 0);
+        CHECK(mock_run.asserts == 1u);
+        CHECK(!last_event.has_value());
+    }
+
+    SECTION("integer != pass") {
+        int value1 = 0;
+        int value2 = 1;
+
+#define SNATCH_CURRENT_TEST mock_run
+        SNATCH_CHECK(value1 != value2);
+#undef SNATCH_CURRENT_TEST
+
+        CHECK(value1 == 0);
+        CHECK(value2 == 1);
+        CHECK(mock_run.asserts == 1u);
+        CHECK(!last_event.has_value());
+    }
+
+    SECTION("integer < pass") {
+        int value1 = 0;
+        int value2 = 1;
+
+#define SNATCH_CURRENT_TEST mock_run
+        SNATCH_CHECK(value1 < value2);
+#undef SNATCH_CURRENT_TEST
+
+        CHECK(value1 == 0);
+        CHECK(value2 == 1);
+        CHECK(mock_run.asserts == 1u);
+        CHECK(!last_event.has_value());
+    }
+
+    SECTION("integer > pass") {
+        int value1 = 1;
+        int value2 = 0;
+
+#define SNATCH_CURRENT_TEST mock_run
+        SNATCH_CHECK(value1 > value2);
+#undef SNATCH_CURRENT_TEST
+
+        CHECK(value1 == 1);
+        CHECK(value2 == 0);
+        CHECK(mock_run.asserts == 1u);
+        CHECK(!last_event.has_value());
+    }
+
+    SECTION("integer <= pass") {
+        int value1 = 0;
+        int value2 = 1;
+
+#define SNATCH_CURRENT_TEST mock_run
+        SNATCH_CHECK(value1 <= value2);
+#undef SNATCH_CURRENT_TEST
+
+        CHECK(value1 == 0);
+        CHECK(value2 == 1);
+        CHECK(mock_run.asserts == 1u);
+        CHECK(!last_event.has_value());
+    }
+
+    SECTION("integer >= pass") {
+        int value1 = 1;
+        int value2 = 0;
+
+#define SNATCH_CURRENT_TEST mock_run
+        SNATCH_CHECK(value1 >= value2);
+#undef SNATCH_CURRENT_TEST
+
+        CHECK(value1 == 1);
+        CHECK(value2 == 0);
+        CHECK(mock_run.asserts == 1u);
+        CHECK(!last_event.has_value());
+    }
+
+    SECTION("integer == fail") {
+        int value1 = 0;
+        int value2 = 1;
+
+#define SNATCH_CURRENT_TEST mock_run
+        // clang-format off
+        SNATCH_CHECK(value1 == value2); const std::size_t failure_line = __LINE__;
+        // clang-foramt on
+#undef SNATCH_CURRENT_TEST
+
+        CHECK(value1 == 0);
+        CHECK(value2 == 1);
+        CHECK(mock_run.asserts == 1u);
+
+        REQUIRE(last_event.has_value());
+        const auto& event = last_event.value();
+        CHECK(event.event_type == event_deep_copy::type::assertion_failed);
+
+        CHECK_EVENT_TEST_ID(event, mock_case.id);
+        CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
+        CHECK(event.message == "CHECK(value1 == value2), got 0 != 1"sv);
+    }
+
+    SECTION("integer != fail") {
+        int value1 = 0;
+        int value2 = 0;
+
+#define SNATCH_CURRENT_TEST mock_run
+        // clang-format off
+        SNATCH_CHECK(value1 != value2); const std::size_t failure_line = __LINE__;
+        // clang-foramt on
+#undef SNATCH_CURRENT_TEST
+
+        CHECK(value1 == 0);
+        CHECK(value2 == 0);
+        CHECK(mock_run.asserts == 1u);
+
+        REQUIRE(last_event.has_value());
+        const auto& event = last_event.value();
+        CHECK(event.event_type == event_deep_copy::type::assertion_failed);
+
+        CHECK_EVENT_TEST_ID(event, mock_case.id);
+        CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
+        CHECK(event.message == "CHECK(value1 != value2), got 0 == 0"sv);
+    }
+
+    SECTION("integer < fail") {
+        int value1 = 1;
+        int value2 = 0;
+
+#define SNATCH_CURRENT_TEST mock_run
+        // clang-format off
+        SNATCH_CHECK(value1 < value2); const std::size_t failure_line = __LINE__;
+        // clang-foramt on
+#undef SNATCH_CURRENT_TEST
+
+        CHECK(value1 == 1);
+        CHECK(value2 == 0);
+        CHECK(mock_run.asserts == 1u);
+
+        REQUIRE(last_event.has_value());
+        const auto& event = last_event.value();
+        CHECK(event.event_type == event_deep_copy::type::assertion_failed);
+
+        CHECK_EVENT_TEST_ID(event, mock_case.id);
+        CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
+        CHECK(event.message == "CHECK(value1 < value2), got 1 >= 0"sv);
+    }
+
+    SECTION("integer > fail") {
+        int value1 = 0;
+        int value2 = 1;
+
+#define SNATCH_CURRENT_TEST mock_run
+        // clang-format off
+        SNATCH_CHECK(value1 > value2); const std::size_t failure_line = __LINE__;
+        // clang-foramt on
+#undef SNATCH_CURRENT_TEST
+
+        CHECK(value1 == 0);
+        CHECK(value2 == 1);
+        CHECK(mock_run.asserts == 1u);
+
+        REQUIRE(last_event.has_value());
+        const auto& event = last_event.value();
+        CHECK(event.event_type == event_deep_copy::type::assertion_failed);
+
+        CHECK_EVENT_TEST_ID(event, mock_case.id);
+        CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
+        CHECK(event.message == "CHECK(value1 > value2), got 0 <= 1"sv);
+    }
+
+    SECTION("integer <= fail") {
+        int value1 = 1;
+        int value2 = 0;
+
+#define SNATCH_CURRENT_TEST mock_run
+        // clang-format off
+        SNATCH_CHECK(value1 <= value2); const std::size_t failure_line = __LINE__;
+        // clang-foramt on
+#undef SNATCH_CURRENT_TEST
+
+        CHECK(value1 == 1);
+        CHECK(value2 == 0);
+        CHECK(mock_run.asserts == 1u);
+
+        REQUIRE(last_event.has_value());
+        const auto& event = last_event.value();
+        CHECK(event.event_type == event_deep_copy::type::assertion_failed);
+
+        CHECK_EVENT_TEST_ID(event, mock_case.id);
+        CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
+        CHECK(event.message == "CHECK(value1 <= value2), got 1 > 0"sv);
+    }
+
+    SECTION("integer >= fail") {
+        int value1 = 0;
+        int value2 = 1;
+
+#define SNATCH_CURRENT_TEST mock_run
+        // clang-format off
+        SNATCH_CHECK(value1 >= value2); const std::size_t failure_line = __LINE__;
+        // clang-foramt on
+#undef SNATCH_CURRENT_TEST
+
+        CHECK(value1 == 0);
+        CHECK(value2 == 1);
+        CHECK(mock_run.asserts == 1u);
+
+        REQUIRE(last_event.has_value());
+        const auto& event = last_event.value();
+        CHECK(event.event_type == event_deep_copy::type::assertion_failed);
+
+        CHECK_EVENT_TEST_ID(event, mock_case.id);
+        CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
+        CHECK(event.message == "CHECK(value1 >= value2), got 0 < 1"sv);
+    }
+};
+
+TEST_CASE("check misc", "[test macros]") {
+    snatch::registry mock_registry;
+
+    snatch::impl::test_case mock_case{
+        .id    = {"mock_test", "[mock_tag]", "mock_type"},
+        .func  = nullptr,
+        .state = snatch::impl::test_state::not_run};
+
+    snatch::impl::test_run mock_run {
+        .reg = mock_registry, .test = mock_case, .sections = {}, .captures = {}, .asserts = 0,
+#if SNATCH_WITH_TIMINGS
+        .duration = 0.0f
+#endif
+    };
+
+    std::optional<event_deep_copy> last_event;
+    auto report = [&](const snatch::registry&, const snatch::event::data& e) noexcept {
+        last_event.emplace(deep_copy(e));
+    };
+
+    mock_registry.report_callback = report;
 
     SECTION("out of space") {
         constexpr std::size_t large_string_length = 768;

--- a/tests/runtime_tests/check.cpp
+++ b/tests/runtime_tests/check.cpp
@@ -199,4 +199,228 @@ TEST_CASE("check", "[test macros]") {
             CHECK(event.message == "CHECK(value++), got 0"sv);
         }
     }
+
+    SECTION("binary") {
+        SECTION("integer == pass") {
+            int value1 = 0;
+            int value2 = 0;
+
+#define SNATCH_CURRENT_TEST mock_run
+            SNATCH_CHECK(value1 == value2);
+#undef SNATCH_CURRENT_TEST
+
+            CHECK(value1 == 0);
+            CHECK(value2 == 0);
+            CHECK(mock_run.asserts == 1u);
+            CHECK(!last_event.has_value());
+        }
+
+        SECTION("integer != pass") {
+            int value1 = 0;
+            int value2 = 1;
+
+#define SNATCH_CURRENT_TEST mock_run
+            SNATCH_CHECK(value1 != value2);
+#undef SNATCH_CURRENT_TEST
+
+            CHECK(value1 == 0);
+            CHECK(value2 == 1);
+            CHECK(mock_run.asserts == 1u);
+            CHECK(!last_event.has_value());
+        }
+
+        SECTION("integer < pass") {
+            int value1 = 0;
+            int value2 = 1;
+
+#define SNATCH_CURRENT_TEST mock_run
+            SNATCH_CHECK(value1 < value2);
+#undef SNATCH_CURRENT_TEST
+
+            CHECK(value1 == 0);
+            CHECK(value2 == 1);
+            CHECK(mock_run.asserts == 1u);
+            CHECK(!last_event.has_value());
+        }
+
+        SECTION("integer > pass") {
+            int value1 = 1;
+            int value2 = 0;
+
+#define SNATCH_CURRENT_TEST mock_run
+            SNATCH_CHECK(value1 > value2);
+#undef SNATCH_CURRENT_TEST
+
+            CHECK(value1 == 1);
+            CHECK(value2 == 0);
+            CHECK(mock_run.asserts == 1u);
+            CHECK(!last_event.has_value());
+        }
+
+        SECTION("integer <= pass") {
+            int value1 = 0;
+            int value2 = 1;
+
+#define SNATCH_CURRENT_TEST mock_run
+            SNATCH_CHECK(value1 <= value2);
+#undef SNATCH_CURRENT_TEST
+
+            CHECK(value1 == 0);
+            CHECK(value2 == 1);
+            CHECK(mock_run.asserts == 1u);
+            CHECK(!last_event.has_value());
+        }
+
+        SECTION("integer >= pass") {
+            int value1 = 1;
+            int value2 = 0;
+
+#define SNATCH_CURRENT_TEST mock_run
+            SNATCH_CHECK(value1 >= value2);
+#undef SNATCH_CURRENT_TEST
+
+            CHECK(value1 == 1);
+            CHECK(value2 == 0);
+            CHECK(mock_run.asserts == 1u);
+            CHECK(!last_event.has_value());
+        }
+
+        SECTION("integer == fail") {
+            int value1 = 0;
+            int value2 = 1;
+
+#define SNATCH_CURRENT_TEST mock_run
+            // clang-format off
+            SNATCH_CHECK(value1 == value2); const std::size_t failure_line = __LINE__;
+            // clang-foramt on
+#undef SNATCH_CURRENT_TEST
+
+            CHECK(value1 == 0);
+            CHECK(value2 == 1);
+            CHECK(mock_run.asserts == 1u);
+
+            REQUIRE(last_event.has_value());
+            const auto& event = last_event.value();
+            CHECK(event.event_type == event_deep_copy::type::assertion_failed);
+
+            CHECK_EVENT_TEST_ID(event, mock_case.id);
+            CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
+            CHECK(event.message == "CHECK(value1 == value2), got 0 != 1"sv);
+        }
+
+        SECTION("integer != fail") {
+            int value1 = 0;
+            int value2 = 0;
+
+#define SNATCH_CURRENT_TEST mock_run
+            // clang-format off
+            SNATCH_CHECK(value1 != value2); const std::size_t failure_line = __LINE__;
+            // clang-foramt on
+#undef SNATCH_CURRENT_TEST
+
+            CHECK(value1 == 0);
+            CHECK(value2 == 0);
+            CHECK(mock_run.asserts == 1u);
+
+            REQUIRE(last_event.has_value());
+            const auto& event = last_event.value();
+            CHECK(event.event_type == event_deep_copy::type::assertion_failed);
+
+            CHECK_EVENT_TEST_ID(event, mock_case.id);
+            CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
+            CHECK(event.message == "CHECK(value1 != value2), got 0 == 0"sv);
+        }
+
+        SECTION("integer < fail") {
+            int value1 = 1;
+            int value2 = 0;
+
+#define SNATCH_CURRENT_TEST mock_run
+            // clang-format off
+            SNATCH_CHECK(value1 < value2); const std::size_t failure_line = __LINE__;
+            // clang-foramt on
+#undef SNATCH_CURRENT_TEST
+
+            CHECK(value1 == 1);
+            CHECK(value2 == 0);
+            CHECK(mock_run.asserts == 1u);
+
+            REQUIRE(last_event.has_value());
+            const auto& event = last_event.value();
+            CHECK(event.event_type == event_deep_copy::type::assertion_failed);
+
+            CHECK_EVENT_TEST_ID(event, mock_case.id);
+            CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
+            CHECK(event.message == "CHECK(value1 < value2), got 1 >= 0"sv);
+        }
+
+        SECTION("integer > fail") {
+            int value1 = 0;
+            int value2 = 1;
+
+#define SNATCH_CURRENT_TEST mock_run
+            // clang-format off
+            SNATCH_CHECK(value1 > value2); const std::size_t failure_line = __LINE__;
+            // clang-foramt on
+#undef SNATCH_CURRENT_TEST
+
+            CHECK(value1 == 0);
+            CHECK(value2 == 1);
+            CHECK(mock_run.asserts == 1u);
+
+            REQUIRE(last_event.has_value());
+            const auto& event = last_event.value();
+            CHECK(event.event_type == event_deep_copy::type::assertion_failed);
+
+            CHECK_EVENT_TEST_ID(event, mock_case.id);
+            CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
+            CHECK(event.message == "CHECK(value1 > value2), got 0 <= 1"sv);
+        }
+
+        SECTION("integer <= fail") {
+            int value1 = 1;
+            int value2 = 0;
+
+#define SNATCH_CURRENT_TEST mock_run
+            // clang-format off
+            SNATCH_CHECK(value1 <= value2); const std::size_t failure_line = __LINE__;
+            // clang-foramt on
+#undef SNATCH_CURRENT_TEST
+
+            CHECK(value1 == 1);
+            CHECK(value2 == 0);
+            CHECK(mock_run.asserts == 1u);
+
+            REQUIRE(last_event.has_value());
+            const auto& event = last_event.value();
+            CHECK(event.event_type == event_deep_copy::type::assertion_failed);
+
+            CHECK_EVENT_TEST_ID(event, mock_case.id);
+            CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
+            CHECK(event.message == "CHECK(value1 <= value2), got 1 > 0"sv);
+        }
+
+        SECTION("integer >= fail") {
+            int value1 = 0;
+            int value2 = 1;
+
+#define SNATCH_CURRENT_TEST mock_run
+            // clang-format off
+            SNATCH_CHECK(value1 >= value2); const std::size_t failure_line = __LINE__;
+            // clang-foramt on
+#undef SNATCH_CURRENT_TEST
+
+            CHECK(value1 == 0);
+            CHECK(value2 == 1);
+            CHECK(mock_run.asserts == 1u);
+
+            REQUIRE(last_event.has_value());
+            const auto& event = last_event.value();
+            CHECK(event.event_type == event_deep_copy::type::assertion_failed);
+
+            CHECK_EVENT_TEST_ID(event, mock_case.id);
+            CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
+            CHECK(event.message == "CHECK(value1 >= value2), got 0 < 1"sv);
+        }
+    }
 };

--- a/tests/runtime_tests/check.cpp
+++ b/tests/runtime_tests/check.cpp
@@ -1,5 +1,7 @@
 #include "testing.hpp"
 
+#include <algorithm>
+
 using namespace std::literals;
 
 struct event_deep_copy {
@@ -422,5 +424,32 @@ TEST_CASE("check", "[test macros]") {
             CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
             CHECK(event.message == "CHECK(value1 >= value2), got 0 < 1"sv);
         }
+    }
+
+    SECTION("out of space") {
+        constexpr std::size_t large_string_length = 768;
+        snatch::small_string<large_string_length> string1;
+        snatch::small_string<large_string_length> string2;
+
+        string1.resize(large_string_length);
+        string2.resize(large_string_length);
+        std::fill(string1.begin(), string1.end(), '0');
+        std::fill(string2.begin(), string2.end(), '1');
+
+#define SNATCH_CURRENT_TEST mock_run
+        // clang-format off
+        SNATCH_CHECK(string1.str() == string2.str()); const std::size_t failure_line = __LINE__;
+        // clang-foramt on
+#undef SNATCH_CURRENT_TEST
+
+        CHECK(mock_run.asserts == 1u);
+
+        REQUIRE(last_event.has_value());
+        const auto& event = last_event.value();
+        CHECK(event.event_type == event_deep_copy::type::assertion_failed);
+
+        CHECK_EVENT_TEST_ID(event, mock_case.id);
+        CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
+        CHECK(event.message == "CHECK(string1.str() == string2.str())"sv);
     }
 };

--- a/tests/runtime_tests/check.cpp
+++ b/tests/runtime_tests/check.cpp
@@ -1,0 +1,97 @@
+#include "testing.hpp"
+
+using namespace std::literals;
+
+struct event_deep_copy {
+    enum class type { unknown, assertion_failed };
+
+    type event_type = type::unknown;
+
+    snatch::small_string<snatch::max_test_name_length> test_id_name;
+    snatch::small_string<snatch::max_test_name_length> test_id_tags;
+    snatch::small_string<snatch::max_test_name_length> test_id_type;
+
+    snatch::small_string<snatch::max_message_length> location_file;
+    std::size_t                                      location_line = 0u;
+
+    snatch::small_string<snatch::max_message_length> message;
+};
+
+event_deep_copy deep_copy(const snatch::event::data& e) {
+    return std::visit(
+        snatch::overload(
+            [](const snatch::event::assertion_failed& a) {
+                event_deep_copy c;
+                c.event_type = event_deep_copy::type::assertion_failed;
+                append_or_truncate(c.test_id_name, a.id.name);
+                append_or_truncate(c.test_id_tags, a.id.tags);
+                append_or_truncate(c.test_id_type, a.id.type);
+                append_or_truncate(c.location_file, a.location.file);
+                c.location_line = a.location.line;
+                append_or_truncate(c.message, a.message);
+                return c;
+            },
+            [](const auto&) -> event_deep_copy { snatch::terminate_with("event not handled"); }),
+        e);
+}
+
+TEST_CASE("check", "[test macros]") {
+    snatch::registry mock_registry;
+
+    snatch::impl::test_case mock_case{
+        .id    = {"mock_test", "[mock_tag]", "mock_type"},
+        .func  = nullptr,
+        .state = snatch::impl::test_state::not_run};
+
+    snatch::impl::test_run mock_run {
+        .reg = mock_registry, .test = mock_case, .sections = {}, .captures = {}, .asserts = 0,
+#if SNATCH_WITH_TIMINGS
+        .duration = 0.0f
+#endif
+    };
+
+    std::optional<event_deep_copy> last_event;
+    auto report = [&](const snatch::registry&, const snatch::event::data& e) noexcept {
+        last_event.emplace(deep_copy(e));
+    };
+
+    mock_registry.report_callback = report;
+
+    SECTION("unary") {
+        SECTION("bool true") {
+            const bool value = true;
+
+#define SNATCH_CURRENT_TEST mock_run
+            SNATCH_CHECK(value);
+#undef SNATCH_CURRENT_TEST
+
+            CHECK(value == true);
+            CHECK(mock_run.asserts == 1u);
+            CHECK(!last_event.has_value());
+        }
+
+        SECTION("bool false") {
+            const bool value = false;
+
+#define SNATCH_CURRENT_TEST mock_run
+            // clang-format off
+            SNATCH_CHECK(value); const std::size_t failure_line = __LINE__;
+            // clang-format on
+#undef SNATCH_CURRENT_TEST
+
+            CHECK(value == false);
+            CHECK(mock_run.asserts == 1u);
+
+            REQUIRE(last_event.has_value());
+            const auto& event = last_event.value();
+            CHECK(event.event_type == event_deep_copy::type::assertion_failed);
+
+            CHECK(event.test_id_name == mock_case.id.name);
+            CHECK(event.test_id_tags == mock_case.id.tags);
+            CHECK(event.test_id_type == mock_case.id.type);
+            CHECK(event.location_file == std::string_view(__FILE__));
+            CHECK(event.location_line == failure_line);
+            CHECK(event.message == "CHECK(value), got false"sv);
+        }
+    }
+};

--- a/tests/runtime_tests/check.cpp
+++ b/tests/runtime_tests/check.cpp
@@ -200,6 +200,171 @@ TEST_CASE("check", "[test macros]") {
             CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
             CHECK(event.message == "CHECK(value++), got 0"sv);
         }
+
+        SECTION("integer expression * pass") {
+            int value = 1;
+
+#define SNATCH_CURRENT_TEST mock_run
+            SNATCH_CHECK(2 * value);
+#undef SNATCH_CURRENT_TEST
+
+            CHECK(value == 1);
+            CHECK(mock_run.asserts == 1u);
+            CHECK(!last_event.has_value());
+        }
+
+        SECTION("integer expression / pass") {
+            int value = 1;
+
+#define SNATCH_CURRENT_TEST mock_run
+            SNATCH_CHECK(2 / value);
+#undef SNATCH_CURRENT_TEST
+
+            CHECK(value == 1);
+            CHECK(mock_run.asserts == 1u);
+            CHECK(!last_event.has_value());
+        }
+
+        SECTION("integer expression + pass") {
+            int value = 1;
+
+#define SNATCH_CURRENT_TEST mock_run
+            SNATCH_CHECK(2 + value);
+#undef SNATCH_CURRENT_TEST
+
+            CHECK(value == 1);
+            CHECK(mock_run.asserts == 1u);
+            CHECK(!last_event.has_value());
+        }
+
+        SECTION("integer expression - pass") {
+            int value = 3;
+
+#define SNATCH_CURRENT_TEST mock_run
+            SNATCH_CHECK(2 - value);
+#undef SNATCH_CURRENT_TEST
+
+            CHECK(value == 3);
+            CHECK(mock_run.asserts == 1u);
+            CHECK(!last_event.has_value());
+        }
+
+        SECTION("integer expression % pass") {
+            int value = 3;
+
+#define SNATCH_CURRENT_TEST mock_run
+            SNATCH_CHECK(2 % value);
+#undef SNATCH_CURRENT_TEST
+
+            CHECK(value == 3);
+            CHECK(mock_run.asserts == 1u);
+            CHECK(!last_event.has_value());
+        }
+
+        SECTION("integer expression * fail") {
+            int value = 0;
+
+#define SNATCH_CURRENT_TEST mock_run
+            // clang-format off
+            SNATCH_CHECK(2 * value); const std::size_t failure_line = __LINE__;
+            // clang-format on
+#undef SNATCH_CURRENT_TEST
+
+            CHECK(value == 0);
+            CHECK(mock_run.asserts == 1u);
+
+            REQUIRE(last_event.has_value());
+            const auto& event = last_event.value();
+            CHECK(event.event_type == event_deep_copy::type::assertion_failed);
+
+            CHECK_EVENT_TEST_ID(event, mock_case.id);
+            CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
+            CHECK(event.message == "CHECK(2 * value), got 0"sv);
+        }
+
+        SECTION("integer expression / fail") {
+            int value = 5;
+
+#define SNATCH_CURRENT_TEST mock_run
+            // clang-format off
+            SNATCH_CHECK(2 / value); const std::size_t failure_line = __LINE__;
+            // clang-format on
+#undef SNATCH_CURRENT_TEST
+
+            CHECK(value == 5);
+            CHECK(mock_run.asserts == 1u);
+
+            REQUIRE(last_event.has_value());
+            const auto& event = last_event.value();
+            CHECK(event.event_type == event_deep_copy::type::assertion_failed);
+
+            CHECK_EVENT_TEST_ID(event, mock_case.id);
+            CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
+            CHECK(event.message == "CHECK(2 / value), got 0"sv);
+        }
+
+        SECTION("integer expression + fail") {
+            int value = -2;
+
+#define SNATCH_CURRENT_TEST mock_run
+            // clang-format off
+            SNATCH_CHECK(2 + value); const std::size_t failure_line = __LINE__;
+            // clang-format on
+#undef SNATCH_CURRENT_TEST
+
+            CHECK(value == -2);
+            CHECK(mock_run.asserts == 1u);
+
+            REQUIRE(last_event.has_value());
+            const auto& event = last_event.value();
+            CHECK(event.event_type == event_deep_copy::type::assertion_failed);
+
+            CHECK_EVENT_TEST_ID(event, mock_case.id);
+            CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
+            CHECK(event.message == "CHECK(2 + value), got 0"sv);
+        }
+
+        SECTION("integer expression - fail") {
+            int value = 2;
+
+#define SNATCH_CURRENT_TEST mock_run
+            // clang-format off
+            SNATCH_CHECK(2 - value); const std::size_t failure_line = __LINE__;
+            // clang-format on
+#undef SNATCH_CURRENT_TEST
+
+            CHECK(value == 2);
+            CHECK(mock_run.asserts == 1u);
+
+            REQUIRE(last_event.has_value());
+            const auto& event = last_event.value();
+            CHECK(event.event_type == event_deep_copy::type::assertion_failed);
+
+            CHECK_EVENT_TEST_ID(event, mock_case.id);
+            CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
+            CHECK(event.message == "CHECK(2 - value), got 0"sv);
+        }
+
+        SECTION("integer expression % fail") {
+            int value = 1;
+
+#define SNATCH_CURRENT_TEST mock_run
+            // clang-format off
+            SNATCH_CHECK(2 % value); const std::size_t failure_line = __LINE__;
+            // clang-format on
+#undef SNATCH_CURRENT_TEST
+
+            CHECK(value == 1);
+            CHECK(mock_run.asserts == 1u);
+
+            REQUIRE(last_event.has_value());
+            const auto& event = last_event.value();
+            CHECK(event.event_type == event_deep_copy::type::assertion_failed);
+
+            CHECK_EVENT_TEST_ID(event, mock_case.id);
+            CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
+            CHECK(event.message == "CHECK(2 % value), got 0"sv);
+        }
     }
 
     SECTION("binary") {

--- a/tests/runtime_tests/matchers.cpp
+++ b/tests/runtime_tests/matchers.cpp
@@ -1,5 +1,7 @@
 #include "testing.hpp"
 
+#include <stdexcept>
+
 using namespace std::literals;
 
 namespace snatch::matchers {
@@ -30,11 +32,44 @@ struct has_prefix {
 };
 } // namespace snatch::matchers
 
-TEST_CASE("matcher", "[utility]") {
+TEST_CASE("example matcher has_prefix", "[utility]") {
     CHECK("info: hello"sv == snatch::matchers::has_prefix{"info"});
     CHECK("info: hello"sv != snatch::matchers::has_prefix{"warning"});
     CHECK("hello"sv != snatch::matchers::has_prefix{"info"});
     CHECK(snatch::matchers::has_prefix{"info"} == "info: hello"sv);
     CHECK(snatch::matchers::has_prefix{"warning"} != "info: hello"sv);
     CHECK(snatch::matchers::has_prefix{"info"} != "hello"sv);
+};
+
+TEST_CASE("matcher contains_substring", "[utility]") {
+    CHECK("info: hello"sv == snatch::matchers::contains_substring{"hello"});
+    CHECK("info: hello"sv != snatch::matchers::contains_substring{"warning"});
+    CHECK(snatch::matchers::contains_substring{"hello"} == "info: hello"sv);
+    CHECK(snatch::matchers::contains_substring{"warning"} != "info: hello"sv);
+};
+
+TEST_CASE("matcher with_what_contains", "[utility]") {
+    CHECK(std::runtime_error{"not good"} == snatch::matchers::with_what_contains{"good"});
+    CHECK(std::runtime_error{"not good"} == snatch::matchers::with_what_contains{"not good"});
+    CHECK(std::runtime_error{"not good"} != snatch::matchers::with_what_contains{"bad"});
+    CHECK(std::runtime_error{"not good"} != snatch::matchers::with_what_contains{"is good"});
+    CHECK(snatch::matchers::with_what_contains{"good"} == std::runtime_error{"not good"});
+    CHECK(snatch::matchers::with_what_contains{"not good"} == std::runtime_error{"not good"});
+    CHECK(snatch::matchers::with_what_contains{"bad"} != std::runtime_error{"not good"});
+    CHECK(snatch::matchers::with_what_contains{"is good"} != std::runtime_error{"not good"});
+};
+
+TEST_CASE("matcher is_any_of", "[utility]") {
+    CHECK(1u == (snatch::matchers::is_any_of{1u, 2u, 3u}));
+    CHECK(2u == (snatch::matchers::is_any_of{1u, 2u, 3u}));
+    CHECK(3u == (snatch::matchers::is_any_of{1u, 2u, 3u}));
+    CHECK(0u != (snatch::matchers::is_any_of{1u, 2u, 3u}));
+    CHECK(4u != (snatch::matchers::is_any_of{1u, 2u, 3u}));
+    CHECK(5u != (snatch::matchers::is_any_of{1u, 2u, 3u}));
+    CHECK((snatch::matchers::is_any_of{1u, 2u, 3u}) == 1u);
+    CHECK((snatch::matchers::is_any_of{1u, 2u, 3u}) == 2u);
+    CHECK((snatch::matchers::is_any_of{1u, 2u, 3u}) == 3u);
+    CHECK((snatch::matchers::is_any_of{1u, 2u, 3u}) != 0u);
+    CHECK((snatch::matchers::is_any_of{1u, 2u, 3u}) != 4u);
+    CHECK((snatch::matchers::is_any_of{1u, 2u, 3u}) != 5u);
 };

--- a/tests/runtime_tests/matchers.cpp
+++ b/tests/runtime_tests/matchers.cpp
@@ -39,6 +39,15 @@ TEST_CASE("example matcher has_prefix", "[utility]") {
     CHECK(snatch::matchers::has_prefix{"info"} == "info: hello"sv);
     CHECK(snatch::matchers::has_prefix{"warning"} != "info: hello"sv);
     CHECK(snatch::matchers::has_prefix{"info"} != "hello"sv);
+
+    CHECK(
+        snatch::matchers::has_prefix{"info"}.describe_match(
+            "info: hello"sv, snatch::matchers::match_status::matched) ==
+        "found prefix 'info:' in 'info: hello'"sv);
+    CHECK(
+        snatch::matchers::has_prefix{"warning"}.describe_match(
+            "info: hello"sv, snatch::matchers::match_status::failed) ==
+        "could not find prefix 'warning:' in 'info: hello'; found prefix 'info:'"sv);
 };
 
 TEST_CASE("matcher contains_substring", "[utility]") {
@@ -46,6 +55,15 @@ TEST_CASE("matcher contains_substring", "[utility]") {
     CHECK("info: hello"sv != snatch::matchers::contains_substring{"warning"});
     CHECK(snatch::matchers::contains_substring{"hello"} == "info: hello"sv);
     CHECK(snatch::matchers::contains_substring{"warning"} != "info: hello"sv);
+
+    CHECK(
+        snatch::matchers::contains_substring{"hello"}.describe_match(
+            "info: hello"sv, snatch::matchers::match_status::matched) ==
+        "found 'hello' in 'info: hello'"sv);
+    CHECK(
+        snatch::matchers::contains_substring{"warning"}.describe_match(
+            "info: hello"sv, snatch::matchers::match_status::failed) ==
+        "could not find 'warning' in 'info: hello'"sv);
 };
 
 TEST_CASE("matcher with_what_contains", "[utility]") {
@@ -57,19 +75,37 @@ TEST_CASE("matcher with_what_contains", "[utility]") {
     CHECK(snatch::matchers::with_what_contains{"not good"} == std::runtime_error{"not good"});
     CHECK(snatch::matchers::with_what_contains{"bad"} != std::runtime_error{"not good"});
     CHECK(snatch::matchers::with_what_contains{"is good"} != std::runtime_error{"not good"});
+
+    CHECK(
+        snatch::matchers::with_what_contains{"good"}.describe_match(
+            std::runtime_error{"not good"}, snatch::matchers::match_status::matched) ==
+        "found 'good' in 'not good'"sv);
+    CHECK(
+        snatch::matchers::with_what_contains{"bad"}.describe_match(
+            std::runtime_error{"not good"}, snatch::matchers::match_status::failed) ==
+        "could not find 'bad' in 'not good'"sv);
 };
 
 TEST_CASE("matcher is_any_of", "[utility]") {
-    CHECK(1u == (snatch::matchers::is_any_of{1u, 2u, 3u}));
-    CHECK(2u == (snatch::matchers::is_any_of{1u, 2u, 3u}));
-    CHECK(3u == (snatch::matchers::is_any_of{1u, 2u, 3u}));
-    CHECK(0u != (snatch::matchers::is_any_of{1u, 2u, 3u}));
-    CHECK(4u != (snatch::matchers::is_any_of{1u, 2u, 3u}));
-    CHECK(5u != (snatch::matchers::is_any_of{1u, 2u, 3u}));
-    CHECK((snatch::matchers::is_any_of{1u, 2u, 3u}) == 1u);
-    CHECK((snatch::matchers::is_any_of{1u, 2u, 3u}) == 2u);
-    CHECK((snatch::matchers::is_any_of{1u, 2u, 3u}) == 3u);
-    CHECK((snatch::matchers::is_any_of{1u, 2u, 3u}) != 0u);
-    CHECK((snatch::matchers::is_any_of{1u, 2u, 3u}) != 4u);
-    CHECK((snatch::matchers::is_any_of{1u, 2u, 3u}) != 5u);
+    const auto m = snatch::matchers::is_any_of{1u, 2u, 3u};
+
+    CHECK(1u == m);
+    CHECK(2u == m);
+    CHECK(3u == m);
+    CHECK(0u != m);
+    CHECK(4u != m);
+    CHECK(5u != m);
+    CHECK(m == 1u);
+    CHECK(m == 2u);
+    CHECK(m == 3u);
+    CHECK(m != 0u);
+    CHECK(m != 4u);
+    CHECK(m != 5u);
+
+    CHECK(
+        m.describe_match(2u, snatch::matchers::match_status::matched) ==
+        "'2' was found in {'1', '2', '3'}"sv);
+    CHECK(
+        m.describe_match(5u, snatch::matchers::match_status::failed) ==
+        "'5' was not found in {'1', '2', '3'}"sv);
 };

--- a/tests/runtime_tests/matchers.cpp
+++ b/tests/runtime_tests/matchers.cpp
@@ -31,15 +31,10 @@ struct has_prefix {
 } // namespace snatch::matchers
 
 TEST_CASE("matcher", "[utility]") {
-    // Passes
     CHECK("info: hello"sv == snatch::matchers::has_prefix{"info"});
     CHECK("info: hello"sv != snatch::matchers::has_prefix{"warning"});
     CHECK("hello"sv != snatch::matchers::has_prefix{"info"});
-
-    snatch::matchers::with_what_contains{"error"};
-
-    // Failures
-    // CHECK("warning: hello"sv == snatch::matchers::has_prefix{"info"});
-    // CHECK("warning: hello"sv != snatch::matchers::has_prefix{"warning"});
-    // CHECK("hello"sv == snatch::matchers::has_prefix{"info"});
+    CHECK(snatch::matchers::has_prefix{"info"} == "info: hello"sv);
+    CHECK(snatch::matchers::has_prefix{"warning"} != "info: hello"sv);
+    CHECK(snatch::matchers::has_prefix{"info"} != "hello"sv);
 };

--- a/tests/runtime_tests/matchers.cpp
+++ b/tests/runtime_tests/matchers.cpp
@@ -6,8 +6,6 @@ namespace snatch::matchers {
 struct has_prefix {
     std::string_view prefix;
 
-    explicit has_prefix(std::string_view p) noexcept : prefix(p) {}
-
     bool match(std::string_view s) const noexcept {
         return s.starts_with(prefix) && s.size() >= prefix.size() + 1 && s[prefix.size()] == ':';
     }
@@ -34,12 +32,14 @@ struct has_prefix {
 
 TEST_CASE("matcher", "[utility]") {
     // Passes
-    CHECK("info: hello"sv == snatch::matchers::has_prefix("info"));
-    CHECK("info: hello"sv != snatch::matchers::has_prefix("warning"));
-    CHECK("hello"sv != snatch::matchers::has_prefix("info"));
+    CHECK("info: hello"sv == snatch::matchers::has_prefix{"info"});
+    CHECK("info: hello"sv != snatch::matchers::has_prefix{"warning"});
+    CHECK("hello"sv != snatch::matchers::has_prefix{"info"});
+
+    snatch::matchers::with_what_contains{"error"};
 
     // Failures
-    // CHECK("warning: hello"sv == snatch::matchers::has_prefix("info"));
-    // CHECK("warning: hello"sv != snatch::matchers::has_prefix("warning"));
-    // CHECK("hello"sv == snatch::matchers::has_prefix("info"));
+    // CHECK("warning: hello"sv == snatch::matchers::has_prefix{"info"});
+    // CHECK("warning: hello"sv != snatch::matchers::has_prefix{"warning"});
+    // CHECK("hello"sv == snatch::matchers::has_prefix{"info"});
 };

--- a/tests/runtime_tests/small_function.cpp
+++ b/tests/runtime_tests/small_function.cpp
@@ -127,7 +127,7 @@ TEMPLATE_TEST_CASE(
             CHECK(test_object_instances <= expected_instances);
         }
 
-        SECTION("from lambda") {
+        SECTION("from stateless lambda") {
             f = snatch::small_function<TestType>{[](Args...) noexcept -> R {
                 function_called = true;
                 if constexpr (!std::is_same_v<R, void>) {
@@ -141,6 +141,27 @@ TEMPLATE_TEST_CASE(
             CHECK(function_called);
             if (!std::is_same_v<R, void>) {
                 CHECK(return_value == 45);
+            }
+            CHECK(test_object_instances <= expected_instances);
+        }
+
+        SECTION("from stateful lambda") {
+            int  answer = 46;
+            auto lambda = [&](Args...) noexcept -> R {
+                function_called = true;
+                if constexpr (!std::is_same_v<R, void>) {
+                    return answer;
+                }
+            };
+
+            f = snatch::small_function<TestType>{lambda};
+            CHECK(!f.empty());
+
+            call_function(f);
+
+            CHECK(function_called);
+            if (!std::is_same_v<R, void>) {
+                CHECK(return_value == 46);
             }
             CHECK(test_object_instances <= expected_instances);
         }

--- a/tests/runtime_tests/small_function.cpp
+++ b/tests/runtime_tests/small_function.cpp
@@ -84,8 +84,11 @@ TEMPLATE_TEST_CASE(
         function_called                          = false;
         constexpr std::size_t expected_instances = sizeof...(Args) > 0 ? 3u : 0u;
 
+        CHECK(f.empty());
+
         SECTION("from free function") {
             f = &test_class<TestType>::method_static;
+            CHECK(!f.empty());
 
             call_function(f);
 
@@ -99,6 +102,7 @@ TEMPLATE_TEST_CASE(
         SECTION("from non-const member function") {
             test_class<TestType> obj;
             f = {obj, snatch::constant<&test_class<TestType>::method>{}};
+            CHECK(!f.empty());
 
             call_function(f);
 
@@ -112,6 +116,7 @@ TEMPLATE_TEST_CASE(
         SECTION("from const member function") {
             const test_class<TestType> obj;
             f = {obj, snatch::constant<&test_class<TestType>::method_const>{}};
+            CHECK(!f.empty());
 
             call_function(f);
 
@@ -129,6 +134,7 @@ TEMPLATE_TEST_CASE(
                     return 45;
                 }
             }};
+            CHECK(!f.empty());
 
             call_function(f);
 

--- a/tests/runtime_tests/string_utility.cpp
+++ b/tests/runtime_tests/string_utility.cpp
@@ -6,6 +6,8 @@ constexpr std::size_t max_length = 20u;
 
 using string_type = snatch::small_string<max_length>;
 
+enum class enum_type { value1 = 0, value2 = 12 };
+
 TEMPLATE_TEST_CASE(
     "append",
     "[utility]",
@@ -19,7 +21,8 @@ TEMPLATE_TEST_CASE(
     void*,
     const void*,
     std::nullptr_t,
-    std::string_view) {
+    std::string_view,
+    enum_type) {
 
     auto create_value = []() -> std::pair<TestType, std::string_view> {
         if constexpr (std::is_same_v<TestType, int>) {
@@ -46,6 +49,8 @@ TEMPLATE_TEST_CASE(
             return {{}, "nullptr"};
         } else if constexpr (std::is_same_v<TestType, std::string_view>) {
             return {"hello"sv, "hello"sv};
+        } else if constexpr (std::is_same_v<TestType, enum_type>) {
+            return {enum_type::value2, "12"sv};
         }
     };
 
@@ -75,7 +80,7 @@ TEMPLATE_TEST_CASE(
         CHECK(std::string_view(s).starts_with(initial));
         if constexpr (
             (std::is_arithmetic_v<TestType> && !std::is_same_v<TestType, bool>) ||
-            std::is_pointer_v<TestType>) {
+            std::is_pointer_v<TestType> || std::is_enum_v<TestType>) {
             // We are stuck with snprintf, which insists on writing a null-terminator character,
             // therefore we loose one character at the end.
             CHECK(s.size() == max_length - 1u);


### PR DESCRIPTION
This PR does the following.

Bug fixes:
 - Fixed `REQUIRE()` and `CHECK()` not able to use custom `append()` function if the function is not declared in the `snatch::` namespace.
 - Fixed `snatch::matchers::with_what_contains` matching too eagerly for `match()`, which resulted in ambiguous comparison operator.
 - Fixed incorrect formatting in `snatch::matchers::is_any_of::describe_match`.

Miscelaneous changes:
 - (utility) Added support for stateful lambdas to `small_function`.
 - (tests) Added tests for `SNATCH_CHECK` and expanded existing tests for more corner cases.
 - (internal) Don't refer to global test registry unless absolutely necessary in test macros.