### PR TITLE
Added tests for capture, section, and skip

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -80,11 +80,15 @@ jobs:
     - name: Test (with snatch)
       shell: bash
       working-directory: ${{github.workspace}}/build
+      # Run even if previous tests failed
+      if: always()
       run: cmake --build . --config ${{matrix.build-type}} --target snatch_runtime_tests_self_run
 
     - name: Test header-only (with snatch)
       shell: bash
       working-directory: ${{github.workspace}}/build
+      # Run even if previous tests failed
+      if: always()
       run: cmake --build . --config ${{matrix.build-type}} --target snatch_runtime_tests_self_header_only_run
 
     - name: Compute code coverage

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ include(FetchContent)
 
 FetchContent_Declare(snatch
                      GIT_REPOSITORY https://github.com/cschreib/snatch.git
-                     GIT_TAG        d1db51bb922909e44fc0983f196d9e43e452a8c4)
+                     GIT_TAG        6b71837fc60e2adc0d0d5603e04a16f694445804)
 FetchContent_MakeAvailable(snatch)
 
 set(RUNTIME_TEST_FILES
@@ -132,7 +132,7 @@ include(FetchContent)
 
 FetchContent_Declare(snatch
                      GIT_REPOSITORY https://github.com/cschreib/snatch.git
-                     GIT_TAG        d1db51bb922909e44fc0983f196d9e43e452a8c4)
+                     GIT_TAG        6b71837fc60e2adc0d0d5603e04a16f694445804)
 FetchContent_MakeAvailable(snatch)
 
 set(RUNTIME_TEST_FILES

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ The goal of _snatch_ is to be a simple, cheap, non-invasive, and user-friendly t
 
 - [Features and limitations](#features-and-limitations)
 - [Example](#example)
+- [Example build configurations with CMake](#example-build-configurations-with-cmake)
+    - [Using _snatch_ as a regular library](#using-snatch-as-a-regular-library)
+    - [Using _snatch_ as a header-only library](#using-snatch-as-a-header-only-library)
 - [Benchmark](#benchmark)
 - [Documentation](#documentation)
     - [Test case macros](#test-case-macros)
@@ -93,6 +96,60 @@ TEMPLATE_LIST_TEST_CASE("Template test case with test types specified inside std
 Output:
 
 ![Screenshot from 2022-10-16 16-16-50](https://user-images.githubusercontent.com/2236577/196043558-ed9ab329-5934-4bb3-a422-b48d6781cf96.png)
+
+
+## Example build configurations with CMake
+
+### Using _snatch_ as a regular library
+
+Here is an example CMake file to download _snatch_ and define a test application:
+
+```cmake
+include(FetchContent)
+
+FetchContent_Declare(snatch
+                     GIT_REPOSITORY https://github.com/cschreib/snatch.git
+                     GIT_TAG        d1db51bb922909e44fc0983f196d9e43e452a8c4)
+FetchContent_MakeAvailable(snatch)
+
+set(RUNTIME_TEST_FILES
+  # add your test files here...
+  )
+
+add_executable(my_tests ${YOUR_TEST_FILES})
+target_link_libraries(my_tests PRIVATE snatch::snatch)
+```
+
+_snatch_ will provide the definition of `main()` [unless otherwise specified](#using-your-own-main-function).
+
+
+### Using _snatch_ as a header-only library
+
+Here is an example CMake file to download _snatch_ and define a test application:
+
+```cmake
+include(FetchContent)
+
+FetchContent_Declare(snatch
+                     GIT_REPOSITORY https://github.com/cschreib/snatch.git
+                     GIT_TAG        d1db51bb922909e44fc0983f196d9e43e452a8c4)
+FetchContent_MakeAvailable(snatch)
+
+set(RUNTIME_TEST_FILES
+  # add your test files here...
+  )
+
+add_executable(my_tests ${YOUR_TEST_FILES})
+target_link_libraries(my_tests PRIVATE snatch::snatch-header-only)
+```
+
+One (and only one!) of your test files needs to include _snatch_ as:
+```c++
+#define SNATCH_IMPLEMENTATION
+#include <snatch_all.hpp>
+```
+
+See the documentation for the [header-only mode](#header-only-build) for more information. This will include the definition of `main()` [unless otherwise specified](#using-your-own-main-function).
 
 
 ## Benchmark
@@ -566,7 +623,13 @@ By default _snatch_ defines `main()` for you. To prevent this and provide your o
 set(SNATCH_DEFINE_MAIN OFF)
 ```
 
-just before calling `FetchContent_Declare()`.
+just before calling `FetchContent_Declare()`. If using the header-only mode, this can also be done in the file that defines the _snatch_ implementation:
+
+```c++
+#define SNATCH_IMPLEMENTATION
+#define SNATCH_DEFINE_MAIN 0
+#include <snatch_all.hpp>
+```
 
 Here is a recommended `main()` function that replicates the default behavior of snatch:
 

--- a/README.md
+++ b/README.md
@@ -270,7 +270,9 @@ struct has_prefix {
 
 ### Sections
 
-As in _Catch2_, _snatch_ supports nesting multiple tests inside a single test case, to share set-up/tear-down logic. This is done using the `SECTION("name")` macro. Please see the [Catch2 documentation](https://github.com/catchorg/Catch2/blob/devel/docs/tutorial.md#test-cases-and-sections) for more details. Here is a brief example to demonstrate the flow of the test:
+As in _Catch2_, _snatch_ supports nesting multiple tests inside a single test case, to share set-up/tear-down logic. This is done using the `SECTION("name")` macro. Please see the [Catch2 documentation](https://github.com/catchorg/Catch2/blob/devel/docs/tutorial.md#test-cases-and-sections) for more details. Note: if any exception is thrown inside a section, or if a `REQUIRE()` check fails (or any other check which aborts execution), the whole test case is stopped. No other section will be executed.
+
+Here is a brief example to demonstrate the flow of the test:
 
 ```c++
 TEST_CASE( "test with sections", "[section]" ) {

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -1,66 +1,7 @@
 #ifndef SNATCH_HPP
 #define SNATCH_HPP
 
-// These should be defined from build-time configuration in snatch_config.hpp.
-// In case the user does not want or care to use snatch_config.hpp, provide some
-// sensible defaults here.
-#if !defined(SNATCH_MAX_TEST_CASES)
-#    define SNATCH_MAX_TEST_CASES 5'000
-#endif
-#if !defined(SNATCH_MAX_NESTED_SECTIONS)
-#    define SNATCH_MAX_NESTED_SECTIONS 8
-#endif
-#if !defined(SNATCH_MAX_EXPR_LENGTH)
-#    define SNATCH_MAX_EXPR_LENGTH 1'024
-#endif
-#if !defined(SNATCH_MAX_MESSAGE_LENGTH)
-#    define SNATCH_MAX_MESSAGE_LENGTH 1'024
-#endif
-#if !defined(SNATCH_MAX_TEST_NAME_LENGTH)
-#    define SNATCH_MAX_TEST_NAME_LENGTH 1'024
-#endif
-#if !defined(SNATCH_MAX_CAPTURES)
-#    define SNATCH_MAX_CAPTURES 8
-#endif
-#if !defined(SNATCH_MAX_CAPTURE_LENGTH)
-#    define SNATCH_MAX_CAPTURE_LENGTH 256
-#endif
-#if !defined(SNATCH_MAX_UNIQUE_TAGS)
-#    define SNATCH_MAX_UNIQUE_TAGS 1'024
-#endif
-#if !defined(SNATCH_MAX_COMMAND_LINE_ARGS)
-#    define SNATCH_MAX_COMMAND_LINE_ARGS 1'024
-#endif
-#if !defined(SNATCH_DEFINE_MAIN)
-#    define SNATCH_DEFINE_MAIN 1
-#endif
-#if !defined(SNATCH_WITH_EXCEPTIONS)
-#    define SNATCH_WITH_EXCEPTIONS 1
-#endif
-#if !defined(SNATCH_WITH_TIMINGS)
-#    define SNATCH_WITH_TIMINGS 1
-#endif
-#if !defined(SNATCH_WITH_SHORTHAND_MACROS)
-#    define SNATCH_WITH_SHORTHAND_MACROS 1
-#endif
-#if !defined(SNATCH_DEFAULT_WITH_COLOR)
-#    define SNATCH_DEFAULT_WITH_COLOR 1
-#endif
-
-#if defined(_MSC_VER)
-#    if defined(_KERNEL_MODE) || (defined(_HAS_EXCEPTIONS) && !_HAS_EXCEPTIONS)
-#        define SNATCH_EXCEPTIONS_NOT_AVAILABLE
-#    endif
-#elif defined(__clang__) || defined(__GNUC__)
-#    if !defined(__EXCEPTIONS)
-#        define SNATCH_EXCEPTIONS_NOT_AVAILABLE
-#    endif
-#endif
-
-#if defined(SNATCH_EXCEPTIONS_NOT_AVAILABLE)
-#    undef SNATCH_WITH_EXCEPTIONS
-#    define SNATCH_WITH_EXCEPTIONS 0
-#endif
+#include "snatch/snatch_config.hpp"
 
 #include <array> // for small_vector
 #include <cstddef> // for std::size_t

--- a/include/snatch/snatch_config.hpp.config
+++ b/include/snatch/snatch_config.hpp.config
@@ -53,4 +53,19 @@
 #endif
 // clang-format on
 
+#if defined(_MSC_VER)
+#    if defined(_KERNEL_MODE) || (defined(_HAS_EXCEPTIONS) && !_HAS_EXCEPTIONS)
+#        define SNATCH_EXCEPTIONS_NOT_AVAILABLE
+#    endif
+#elif defined(__clang__) || defined(__GNUC__)
+#    if !defined(__EXCEPTIONS)
+#        define SNATCH_EXCEPTIONS_NOT_AVAILABLE
+#    endif
+#endif
+
+#if defined(SNATCH_EXCEPTIONS_NOT_AVAILABLE)
+#    undef SNATCH_WITH_EXCEPTIONS
+#    define SNATCH_WITH_EXCEPTIONS 0
+#endif
+
 #endif

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -1,7 +1,4 @@
-// clang-format off
-#include "snatch/snatch_config.hpp"
 #include "snatch/snatch.hpp"
-// clang-format on
 
 #include <algorithm> // for std::sort
 #include <cstdio> // for std::printf, std::snprintf

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -336,7 +336,7 @@ std::string_view extract_next_name(std::string_view& names) noexcept {
     bool in_string = false;
     bool in_char   = false;
     int  parens    = 0;
-    while (pos != names.npos && pos != names.size() - 1) {
+    while (pos != names.npos) {
         switch (names[pos]) {
         case '"':
             if (!in_char) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,8 @@ function(add_platform_definitions TARGET)
       target_compile_options(${TARGET} PRIVATE /W4)
       target_compile_options(${TARGET} PRIVATE /WX)
       target_compile_options(${TARGET} PRIVATE /EHs)
+      # Increase default stack size to match default for Linux
+      target_compile_options(${TARGET} PRIVATE "/F 8388608")
     endif()
 endfunction()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,6 +48,7 @@ set(RUNTIME_TEST_FILES
   ${PROJECT_SOURCE_DIR}/tests/runtime_tests/small_function.cpp
   ${PROJECT_SOURCE_DIR}/tests/runtime_tests/matchers.cpp
   ${PROJECT_SOURCE_DIR}/tests/runtime_tests/check.cpp
+  ${PROJECT_SOURCE_DIR}/tests/runtime_tests/skip.cpp
   ${PROJECT_SOURCE_DIR}/tests/runtime_tests/capture.cpp
   ${PROJECT_SOURCE_DIR}/tests/runtime_tests/section.cpp)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,15 @@ function(add_platform_definitions TARGET)
     endif()
 endfunction()
 
+function(configure_snatch_for_tests TARGET)
+  target_compile_definitions(${TARGET} PUBLIC
+    SNATCH_MAX_TEST_CASES=100
+    SNATCH_MAX_EXPR_LENGTH=128
+    SNATCH_MAX_MESSAGE_LENGTH=128
+    SNATCH_MAX_TEST_NAME_LENGTH=128
+    SNATCH_MAX_CAPTURE_LENGTH=128)
+endfunction()
+
 include(FetchContent)
 
 set(DOCTEST_WITH_MAIN_IN_STATIC_LIB ON)
@@ -64,6 +73,7 @@ target_link_libraries(snatch_runtime_tests PRIVATE
   doctest::doctest
   doctest::doctest_with_main)
 add_platform_definitions(snatch_runtime_tests)
+configure_snatch_for_tests(snatch_runtime_tests)
 target_compile_features(snatch_runtime_tests PUBLIC cxx_std_20)
 target_compile_definitions(snatch_runtime_tests PUBLIC
   SNATCH_DEFINE_MAIN=0
@@ -83,8 +93,10 @@ target_include_directories(snatch_runtime_tests_self PRIVATE
   ${PROJECT_BINARY_DIR}
   ${PROJECT_SOURCE_DIR}/tests)
 add_platform_definitions(snatch_runtime_tests_self)
+configure_snatch_for_tests(snatch_runtime_tests_self)
 target_compile_features(snatch_runtime_tests_self PUBLIC cxx_std_20)
-target_compile_definitions(snatch_runtime_tests_self PUBLIC SNATCH_TEST_WITH_SNATCH)
+target_compile_definitions(snatch_runtime_tests_self PUBLIC
+  SNATCH_TEST_WITH_SNATCH)
 
 add_custom_target(snatch_runtime_tests_self_run
   COMMAND snatch_runtime_tests_self
@@ -99,6 +111,7 @@ target_include_directories(snatch_runtime_tests_self_header_only PRIVATE
   ${PROJECT_BINARY_DIR}
   ${PROJECT_SOURCE_DIR}/tests)
 add_platform_definitions(snatch_runtime_tests_self_header_only)
+configure_snatch_for_tests(snatch_runtime_tests_self_header_only)
 target_compile_features(snatch_runtime_tests_self_header_only PUBLIC cxx_std_20)
 target_compile_definitions(snatch_runtime_tests_self_header_only PUBLIC
   SNATCH_TEST_WITH_SNATCH

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,7 +46,8 @@ set(RUNTIME_TEST_FILES
   ${PROJECT_SOURCE_DIR}/tests/runtime_tests/string_utility.cpp
   ${PROJECT_SOURCE_DIR}/tests/runtime_tests/small_function.cpp
   ${PROJECT_SOURCE_DIR}/tests/runtime_tests/matchers.cpp
-  ${PROJECT_SOURCE_DIR}/tests/runtime_tests/check.cpp)
+  ${PROJECT_SOURCE_DIR}/tests/runtime_tests/check.cpp
+  ${PROJECT_SOURCE_DIR}/tests/runtime_tests/capture.cpp)
 
 # Test snatch with doctest
 add_executable(snatch_runtime_tests ${PROJECT_SOURCE_DIR}/src/snatch.cpp ${RUNTIME_TEST_FILES})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ FetchContent_Declare(doctest
 FetchContent_MakeAvailable(doctest)
 
 set(RUNTIME_TEST_FILES
+  ${PROJECT_SOURCE_DIR}/tests/testing_event.cpp
   ${PROJECT_SOURCE_DIR}/tests/runtime_tests/type_name.cpp
   ${PROJECT_SOURCE_DIR}/tests/runtime_tests/small_vector.cpp
   ${PROJECT_SOURCE_DIR}/tests/runtime_tests/small_string.cpp
@@ -47,7 +48,8 @@ set(RUNTIME_TEST_FILES
   ${PROJECT_SOURCE_DIR}/tests/runtime_tests/small_function.cpp
   ${PROJECT_SOURCE_DIR}/tests/runtime_tests/matchers.cpp
   ${PROJECT_SOURCE_DIR}/tests/runtime_tests/check.cpp
-  ${PROJECT_SOURCE_DIR}/tests/runtime_tests/capture.cpp)
+  ${PROJECT_SOURCE_DIR}/tests/runtime_tests/capture.cpp
+  ${PROJECT_SOURCE_DIR}/tests/runtime_tests/section.cpp)
 
 # Test snatch with doctest
 add_executable(snatch_runtime_tests ${PROJECT_SOURCE_DIR}/src/snatch.cpp ${RUNTIME_TEST_FILES})

--- a/tests/runtime_tests/capture.cpp
+++ b/tests/runtime_tests/capture.cpp
@@ -111,12 +111,24 @@ TEST_CASE("capture", "[test macros]") {
     SECTION("expression string") {
         mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             std::string s = "hello";
-            SNATCH_CAPTURE(s + ", 'world'");
+            SNATCH_CAPTURE(s + ", 'world' (string),)(");
             SNATCH_FAIL("trigger");
         };
 
         mock_registry.run(mock_case);
-        CHECK_CAPTURES("s + \", 'world'\" := hello, 'world'");
+        CHECK_CAPTURES("s + \", 'world' (string),)(\" := hello, 'world' (string),)(");
+    }
+
+    SECTION("expression function call & char") {
+        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+            std::string s = "hel\"lo";
+            SNATCH_CAPTURE(s.find_first_of('e'));
+            SNATCH_CAPTURE(s.find_first_of('"'));
+            SNATCH_FAIL("trigger");
+        };
+
+        mock_registry.run(mock_case);
+        CHECK_CAPTURES("s.find_first_of('e') := 1", "s.find_first_of('\"') := 3");
     }
 
     SECTION("two variables") {

--- a/tests/runtime_tests/capture.cpp
+++ b/tests/runtime_tests/capture.cpp
@@ -1,0 +1,52 @@
+#include "testing.hpp"
+#include "testing_event.hpp"
+
+#include <algorithm>
+
+using namespace std::literals;
+
+std::optional<event_deep_copy> get_failure_event(const std::vector<event_deep_copy>& events) {
+    auto iter = std::find_if(events.cbegin(), events.cend(), [](const event_deep_copy& e) {
+        return e.event_type == event_deep_copy::type::assertion_failed;
+    });
+
+    if (iter == events.cend()) {
+        return {};
+    } else {
+        return *iter;
+    }
+}
+
+#define CHECK_CAPTURE(CAPTURED_VALUE)                                                              \
+    do {                                                                                           \
+        auto failure = get_failure_event(events);                                                  \
+        REQUIRE(failure.has_value());                                                              \
+        REQUIRE(failure.value().captures.size() == 1u);                                            \
+        REQUIRE(failure.value().captures[0] == CAPTURED_VALUE##sv);                                \
+    } while (0)
+
+TEST_CASE("capture", "[test macros]") {
+    snatch::registry mock_registry;
+
+    snatch::impl::test_case mock_case{
+        .id    = {"mock_test", "[mock_tag]", "mock_type"},
+        .func  = nullptr,
+        .state = snatch::impl::test_state::not_run};
+
+    std::vector<event_deep_copy> events;
+    auto report = [&](const snatch::registry&, const snatch::event::data& e) noexcept {
+        events.push_back(deep_copy(e));
+    };
+
+    mock_registry.report_callback = report;
+
+    SECTION("literal int") {
+        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+            SNATCH_CAPTURE(1);
+            SNATCH_FAIL("trigger");
+        };
+
+        mock_registry.run(mock_case);
+        CHECK_CAPTURE("1 := 1");
+    }
+};

--- a/tests/runtime_tests/capture.cpp
+++ b/tests/runtime_tests/capture.cpp
@@ -5,6 +5,9 @@
 
 using namespace std::literals;
 
+SNATCH_WARNING_PUSH
+SNATCH_WARNING_DISABLE_UNREACHABLE
+
 TEST_CASE("capture", "[test macros]") {
     mock_framework framework;
 
@@ -320,3 +323,5 @@ TEST_CASE("info", "[test macros]") {
         CHECK_CAPTURES("1", "i := 1");
     }
 };
+
+SNATCH_WARNING_POP

--- a/tests/runtime_tests/capture.cpp
+++ b/tests/runtime_tests/capture.cpp
@@ -6,110 +6,98 @@
 using namespace std::literals;
 
 TEST_CASE("capture", "[test macros]") {
-    snatch::registry mock_registry;
-
-    snatch::impl::test_case mock_case{
-        .id    = {"mock_test", "[mock_tag]", "mock_type"},
-        .func  = nullptr,
-        .state = snatch::impl::test_state::not_run};
-
-    std::vector<event_deep_copy> events;
-    auto report = [&](const snatch::registry&, const snatch::event::data& e) noexcept {
-        events.push_back(deep_copy(e));
-    };
-
-    mock_registry.report_callback = report;
+    mock_framework framework;
 
     SECTION("literal int") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             SNATCH_CAPTURE(1);
             SNATCH_FAIL("trigger");
         };
 
-        mock_registry.run(mock_case);
+        framework.run_test();
         CHECK_CAPTURES("1 := 1");
     }
 
     SECTION("literal string") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             SNATCH_CAPTURE("hello");
             SNATCH_FAIL("trigger");
         };
 
-        mock_registry.run(mock_case);
+        framework.run_test();
         CHECK_CAPTURES("\"hello\" := hello");
     }
 
     SECTION("variable int") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             int i = 1;
             SNATCH_CAPTURE(i);
             SNATCH_FAIL("trigger");
         };
 
-        mock_registry.run(mock_case);
+        framework.run_test();
         CHECK_CAPTURES("i := 1");
     }
 
     SECTION("variable string") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             std::string s = "hello";
             SNATCH_CAPTURE(s);
             SNATCH_FAIL("trigger");
         };
 
-        mock_registry.run(mock_case);
+        framework.run_test();
         CHECK_CAPTURES("s := hello");
     }
 
     SECTION("expression int") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             int i = 1;
             SNATCH_CAPTURE(2 * i + 1);
             SNATCH_FAIL("trigger");
         };
 
-        mock_registry.run(mock_case);
+        framework.run_test();
         CHECK_CAPTURES("2 * i + 1 := 3");
     }
 
     SECTION("expression string") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             std::string s = "hello";
             SNATCH_CAPTURE(s + ", 'world' (string),)(");
             SNATCH_FAIL("trigger");
         };
 
-        mock_registry.run(mock_case);
+        framework.run_test();
         CHECK_CAPTURES("s + \", 'world' (string),)(\" := hello, 'world' (string),)(");
     }
 
     SECTION("expression function call & char") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             std::string s = "hel\"lo";
             SNATCH_CAPTURE(s.find_first_of('e'));
             SNATCH_CAPTURE(s.find_first_of('"'));
             SNATCH_FAIL("trigger");
         };
 
-        mock_registry.run(mock_case);
+        framework.run_test();
         CHECK_CAPTURES("s.find_first_of('e') := 1", "s.find_first_of('\"') := 3");
     }
 
     SECTION("two variables") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             int i = 1;
             int j = 2;
             SNATCH_CAPTURE(i, j);
             SNATCH_FAIL("trigger");
         };
 
-        mock_registry.run(mock_case);
+        framework.run_test();
         CHECK_CAPTURES("i := 1", "j := 2");
     }
 
     SECTION("three variables different types") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             int         i = 1;
             int         j = 2;
             std::string s = "hello";
@@ -117,12 +105,12 @@ TEST_CASE("capture", "[test macros]") {
             SNATCH_FAIL("trigger");
         };
 
-        mock_registry.run(mock_case);
+        framework.run_test();
         CHECK_CAPTURES("i := 1", "j := 2", "s := hello");
     }
 
     SECTION("scoped out") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             {
                 int i = 1;
                 SNATCH_CAPTURE(i);
@@ -130,12 +118,12 @@ TEST_CASE("capture", "[test macros]") {
             SNATCH_FAIL("trigger");
         };
 
-        mock_registry.run(mock_case);
+        framework.run_test();
         CHECK_NO_CAPTURE;
     }
 
     SECTION("scoped out multiple capture") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             int i = 1;
             SNATCH_CAPTURE(i);
 
@@ -147,26 +135,26 @@ TEST_CASE("capture", "[test macros]") {
             SNATCH_FAIL("trigger");
         };
 
-        mock_registry.run(mock_case);
+        framework.run_test();
         CHECK_CAPTURES("i := 1");
     }
 
     SECTION("multiple failures") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             int i = 1;
             SNATCH_CAPTURE(i);
             SNATCH_FAIL_CHECK("trigger1");
             SNATCH_FAIL_CHECK("trigger2");
         };
 
-        mock_registry.run(mock_case);
-        REQUIRE(get_num_failures(events) == 2u);
+        framework.run_test();
+        REQUIRE(framework.get_num_failures() == 2u);
         CHECK_CAPTURES_FOR_FAILURE(0u, "i := 1");
         CHECK_CAPTURES_FOR_FAILURE(1u, "i := 1");
     }
 
     SECTION("multiple failures interleaved") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             int i = 1;
             SNATCH_CAPTURE(i);
             SNATCH_FAIL_CHECK("trigger1");
@@ -174,94 +162,82 @@ TEST_CASE("capture", "[test macros]") {
             SNATCH_FAIL_CHECK("trigger2");
         };
 
-        mock_registry.run(mock_case);
-        REQUIRE(get_num_failures(events) == 2u);
+        framework.run_test();
+        REQUIRE(framework.get_num_failures() == 2u);
         CHECK_CAPTURES_FOR_FAILURE(0u, "i := 1");
         CHECK_CAPTURES_FOR_FAILURE(1u, "i := 1", "2 * i := 2");
     }
 };
 
 TEST_CASE("info", "[test macros]") {
-    snatch::registry mock_registry;
-
-    snatch::impl::test_case mock_case{
-        .id    = {"mock_test", "[mock_tag]", "mock_type"},
-        .func  = nullptr,
-        .state = snatch::impl::test_state::not_run};
-
-    std::vector<event_deep_copy> events;
-    auto report = [&](const snatch::registry&, const snatch::event::data& e) noexcept {
-        events.push_back(deep_copy(e));
-    };
-
-    mock_registry.report_callback = report;
+    mock_framework framework;
 
     SECTION("literal int") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             SNATCH_INFO(1);
             SNATCH_FAIL("trigger");
         };
 
-        mock_registry.run(mock_case);
+        framework.run_test();
         CHECK_CAPTURES("1");
     }
 
     SECTION("literal string") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             SNATCH_INFO("hello");
             SNATCH_FAIL("trigger");
         };
 
-        mock_registry.run(mock_case);
+        framework.run_test();
         CHECK_CAPTURES("hello");
     }
 
     SECTION("variable int") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             int i = 1;
             SNATCH_INFO(i);
             SNATCH_FAIL("trigger");
         };
 
-        mock_registry.run(mock_case);
+        framework.run_test();
         CHECK_CAPTURES("1");
     }
 
     SECTION("variable string") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             std::string s = "hello";
             SNATCH_INFO(s);
             SNATCH_FAIL("trigger");
         };
 
-        mock_registry.run(mock_case);
+        framework.run_test();
         CHECK_CAPTURES("hello");
     }
 
     SECTION("expression int") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             int i = 1;
             SNATCH_INFO(2 * i + 1);
             SNATCH_FAIL("trigger");
         };
 
-        mock_registry.run(mock_case);
+        framework.run_test();
         CHECK_CAPTURES("3");
     }
 
     SECTION("expression string") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             std::string s = "hello";
             SNATCH_INFO(s + ", 'world'");
             SNATCH_FAIL("trigger");
         };
 
-        mock_registry.run(mock_case);
+        framework.run_test();
         CHECK_CAPTURES("hello, 'world'");
     }
 
     SECTION("multiple") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             int         i = 1;
             int         j = 2;
             std::string s = "hello";
@@ -269,12 +245,12 @@ TEST_CASE("info", "[test macros]") {
             SNATCH_FAIL("trigger");
         };
 
-        mock_registry.run(mock_case);
+        framework.run_test();
         CHECK_CAPTURES("1 and 2");
     }
 
     SECTION("scoped out") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             {
                 int i = 1;
                 SNATCH_INFO(i);
@@ -282,12 +258,12 @@ TEST_CASE("info", "[test macros]") {
             SNATCH_FAIL("trigger");
         };
 
-        mock_registry.run(mock_case);
+        framework.run_test();
         CHECK_NO_CAPTURE;
     }
 
     SECTION("scoped out multiple") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             int i = 1;
             SNATCH_INFO(i);
 
@@ -299,26 +275,26 @@ TEST_CASE("info", "[test macros]") {
             SNATCH_FAIL("trigger");
         };
 
-        mock_registry.run(mock_case);
+        framework.run_test();
         CHECK_CAPTURES("1");
     }
 
     SECTION("multiple failures") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             int i = 1;
             SNATCH_INFO(i);
             SNATCH_FAIL_CHECK("trigger1");
             SNATCH_FAIL_CHECK("trigger2");
         };
 
-        mock_registry.run(mock_case);
-        REQUIRE(get_num_failures(events) == 2u);
+        framework.run_test();
+        REQUIRE(framework.get_num_failures() == 2u);
         CHECK_CAPTURES_FOR_FAILURE(0u, "1");
         CHECK_CAPTURES_FOR_FAILURE(1u, "1");
     }
 
     SECTION("multiple failures interleaved") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             int i = 1;
             SNATCH_INFO(i);
             SNATCH_FAIL_CHECK("trigger1");
@@ -326,21 +302,21 @@ TEST_CASE("info", "[test macros]") {
             SNATCH_FAIL_CHECK("trigger2");
         };
 
-        mock_registry.run(mock_case);
-        REQUIRE(get_num_failures(events) == 2u);
+        framework.run_test();
+        REQUIRE(framework.get_num_failures() == 2u);
         CHECK_CAPTURES_FOR_FAILURE(0u, "1");
         CHECK_CAPTURES_FOR_FAILURE(1u, "1", "2");
     }
 
     SECTION("mixed with capture") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             int i = 1;
             SNATCH_INFO(i);
             SNATCH_CAPTURE(i);
             SNATCH_FAIL("trigger");
         };
 
-        mock_registry.run(mock_case);
+        framework.run_test();
         CHECK_CAPTURES("1", "i := 1");
     }
 };

--- a/tests/runtime_tests/capture.cpp
+++ b/tests/runtime_tests/capture.cpp
@@ -2,6 +2,8 @@
 #include "testing_event.hpp"
 
 #include <algorithm>
+#include <string>
+#include <vector>
 
 using namespace std::literals;
 
@@ -17,12 +19,25 @@ std::optional<event_deep_copy> get_failure_event(const std::vector<event_deep_co
     }
 }
 
-#define CHECK_CAPTURE(CAPTURED_VALUE)                                                              \
+#define CHECK_CAPTURES(...)                                                                        \
     do {                                                                                           \
         auto failure = get_failure_event(events);                                                  \
         REQUIRE(failure.has_value());                                                              \
-        REQUIRE(failure.value().captures.size() == 1u);                                            \
-        REQUIRE(failure.value().captures[0] == CAPTURED_VALUE##sv);                                \
+        const char* EXPECTED_CAPTURES[] = {__VA_ARGS__};                                           \
+        REQUIRE(                                                                                   \
+            failure.value().captures.size() == sizeof(EXPECTED_CAPTURES) / sizeof(const char*));   \
+        std::size_t CAPTURE_INDEX = 0;                                                             \
+        for (std::string_view CAPTURED_VALUE : EXPECTED_CAPTURES) {                                \
+            CHECK(failure.value().captures[CAPTURE_INDEX] == CAPTURED_VALUE);                      \
+            ++CAPTURE_INDEX;                                                                       \
+        }                                                                                          \
+    } while (0)
+
+#define CHECK_NO_CAPTURE                                                                           \
+    do {                                                                                           \
+        auto failure = get_failure_event(events);                                                  \
+        REQUIRE(failure.has_value());                                                              \
+        CHECK(failure.value().captures.empty());                                                   \
     } while (0)
 
 TEST_CASE("capture", "[test macros]") {
@@ -47,6 +62,250 @@ TEST_CASE("capture", "[test macros]") {
         };
 
         mock_registry.run(mock_case);
-        CHECK_CAPTURE("1 := 1");
+        CHECK_CAPTURES("1 := 1");
+    }
+
+    SECTION("literal string") {
+        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+            SNATCH_CAPTURE("hello");
+            SNATCH_FAIL("trigger");
+        };
+
+        mock_registry.run(mock_case);
+        CHECK_CAPTURES("\"hello\" := hello");
+    }
+
+    SECTION("variable int") {
+        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+            int i = 1;
+            SNATCH_CAPTURE(i);
+            SNATCH_FAIL("trigger");
+        };
+
+        mock_registry.run(mock_case);
+        CHECK_CAPTURES("i := 1");
+    }
+
+    SECTION("variable string") {
+        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+            std::string s = "hello";
+            SNATCH_CAPTURE(s);
+            SNATCH_FAIL("trigger");
+        };
+
+        mock_registry.run(mock_case);
+        CHECK_CAPTURES("s := hello");
+    }
+
+    SECTION("expression int") {
+        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+            int i = 1;
+            SNATCH_CAPTURE(2 * i + 1);
+            SNATCH_FAIL("trigger");
+        };
+
+        mock_registry.run(mock_case);
+        CHECK_CAPTURES("2 * i + 1 := 3");
+    }
+
+    SECTION("expression string") {
+        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+            std::string s = "hello";
+            SNATCH_CAPTURE(s + ", 'world'");
+            SNATCH_FAIL("trigger");
+        };
+
+        mock_registry.run(mock_case);
+        CHECK_CAPTURES("s + \", 'world'\" := hello, 'world'");
+    }
+
+    SECTION("two variables") {
+        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+            int i = 1;
+            int j = 2;
+            SNATCH_CAPTURE(i, j);
+            SNATCH_FAIL("trigger");
+        };
+
+        mock_registry.run(mock_case);
+        CHECK_CAPTURES("i := 1", "j := 2");
+    }
+
+    SECTION("three variables different types") {
+        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+            int         i = 1;
+            int         j = 2;
+            std::string s = "hello";
+            SNATCH_CAPTURE(i, j, s);
+            SNATCH_FAIL("trigger");
+        };
+
+        mock_registry.run(mock_case);
+        CHECK_CAPTURES("i := 1", "j := 2", "s := hello");
+    }
+
+    SECTION("scoped out") {
+        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+            {
+                int i = 1;
+                SNATCH_CAPTURE(i);
+            }
+            SNATCH_FAIL("trigger");
+        };
+
+        mock_registry.run(mock_case);
+        CHECK_NO_CAPTURE;
+    }
+
+    SECTION("scoped out multiple") {
+        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+            int i = 1;
+            SNATCH_CAPTURE(i);
+
+            {
+                int j = 2;
+                SNATCH_CAPTURE(j);
+            }
+
+            SNATCH_FAIL("trigger");
+        };
+
+        mock_registry.run(mock_case);
+        CHECK_CAPTURES("i := 1");
+    }
+};
+
+TEST_CASE("info", "[test macros]") {
+    snatch::registry mock_registry;
+
+    snatch::impl::test_case mock_case{
+        .id    = {"mock_test", "[mock_tag]", "mock_type"},
+        .func  = nullptr,
+        .state = snatch::impl::test_state::not_run};
+
+    std::vector<event_deep_copy> events;
+    auto report = [&](const snatch::registry&, const snatch::event::data& e) noexcept {
+        events.push_back(deep_copy(e));
+    };
+
+    mock_registry.report_callback = report;
+
+    SECTION("literal int") {
+        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+            SNATCH_INFO(1);
+            SNATCH_FAIL("trigger");
+        };
+
+        mock_registry.run(mock_case);
+        CHECK_CAPTURES("1");
+    }
+
+    SECTION("literal string") {
+        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+            SNATCH_INFO("hello");
+            SNATCH_FAIL("trigger");
+        };
+
+        mock_registry.run(mock_case);
+        CHECK_CAPTURES("hello");
+    }
+
+    SECTION("variable int") {
+        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+            int i = 1;
+            SNATCH_INFO(i);
+            SNATCH_FAIL("trigger");
+        };
+
+        mock_registry.run(mock_case);
+        CHECK_CAPTURES("1");
+    }
+
+    SECTION("variable string") {
+        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+            std::string s = "hello";
+            SNATCH_INFO(s);
+            SNATCH_FAIL("trigger");
+        };
+
+        mock_registry.run(mock_case);
+        CHECK_CAPTURES("hello");
+    }
+
+    SECTION("expression int") {
+        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+            int i = 1;
+            SNATCH_INFO(2 * i + 1);
+            SNATCH_FAIL("trigger");
+        };
+
+        mock_registry.run(mock_case);
+        CHECK_CAPTURES("3");
+    }
+
+    SECTION("expression string") {
+        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+            std::string s = "hello";
+            SNATCH_INFO(s + ", 'world'");
+            SNATCH_FAIL("trigger");
+        };
+
+        mock_registry.run(mock_case);
+        CHECK_CAPTURES("hello, 'world'");
+    }
+
+    SECTION("multiple") {
+        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+            int         i = 1;
+            int         j = 2;
+            std::string s = "hello";
+            SNATCH_INFO(i, " and ", j);
+            SNATCH_FAIL("trigger");
+        };
+
+        mock_registry.run(mock_case);
+        CHECK_CAPTURES("1 and 2");
+    }
+
+    SECTION("scoped out") {
+        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+            {
+                int i = 1;
+                SNATCH_INFO(i);
+            }
+            SNATCH_FAIL("trigger");
+        };
+
+        mock_registry.run(mock_case);
+        CHECK_NO_CAPTURE;
+    }
+
+    SECTION("scoped out multiple") {
+        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+            int i = 1;
+            SNATCH_INFO(i);
+
+            {
+                int j = 2;
+                SNATCH_INFO(j);
+            }
+
+            SNATCH_FAIL("trigger");
+        };
+
+        mock_registry.run(mock_case);
+        CHECK_CAPTURES("1");
+    }
+
+    SECTION("mixed with capture") {
+        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+            int i = 1;
+            SNATCH_INFO(i);
+            SNATCH_CAPTURE(i);
+            SNATCH_FAIL("trigger");
+        };
+
+        mock_registry.run(mock_case);
+        CHECK_CAPTURES("1", "i := 1");
     }
 };

--- a/tests/runtime_tests/section.cpp
+++ b/tests/runtime_tests/section.cpp
@@ -1,6 +1,7 @@
 #include "testing.hpp"
 #include "testing_event.hpp"
 
+#include <stdexcept>
 #include <string>
 
 using namespace std::literals;

--- a/tests/runtime_tests/section.cpp
+++ b/tests/runtime_tests/section.cpp
@@ -6,6 +6,9 @@
 
 using namespace std::literals;
 
+SNATCH_WARNING_PUSH
+SNATCH_WARNING_DISABLE_UNREACHABLE
+
 TEST_CASE("section", "[test macros]") {
     snatch::registry mock_registry;
 
@@ -77,9 +80,6 @@ TEST_CASE("section", "[test macros]") {
         CHECK_SECTIONS_FOR_FAILURE(1u, "section 1", "section 1.1");
     }
 
-    SNATCH_WARNING_PUSH
-    SNATCH_WARNING_DISABLE_UNREACHABLE
-
     SECTION("nested sections abort early") {
         mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             SNATCH_SECTION("section 1") {
@@ -137,8 +137,6 @@ TEST_CASE("section", "[test macros]") {
         CHECK_NO_SECTION;
     }
 
-    SNATCH_WARNING_POP
-
     SECTION("nested sections varying depth") {
         mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             SNATCH_SECTION("section 1") {
@@ -174,6 +172,8 @@ TEST_CASE("section", "[test macros]") {
         CHECK_SECTIONS_FOR_FAILURE(4u, "section 3");
     }
 };
+
+SNATCH_WARNING_POP
 
 TEST_CASE("section readme example", "[test macros]") {
     snatch::registry mock_registry;

--- a/tests/runtime_tests/section.cpp
+++ b/tests/runtime_tests/section.cpp
@@ -76,6 +76,9 @@ TEST_CASE("section", "[test macros]") {
         CHECK_SECTIONS_FOR_FAILURE(1u, "section 1", "section 1.1");
     }
 
+    SNATCH_WARNING_PUSH
+    SNATCH_WARNING_DISABLE_UNREACHABLE
+
     SECTION("nested sections abort early") {
         mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             SNATCH_SECTION("section 1") {
@@ -132,6 +135,8 @@ TEST_CASE("section", "[test macros]") {
         REQUIRE(get_num_failures(events) == 1u);
         CHECK_NO_SECTION;
     }
+
+    SNATCH_WARNING_POP
 
     SECTION("nested sections varying depth") {
         mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {

--- a/tests/runtime_tests/section.cpp
+++ b/tests/runtime_tests/section.cpp
@@ -1,0 +1,176 @@
+#include "testing.hpp"
+#include "testing_event.hpp"
+
+#include <string>
+
+using namespace std::literals;
+
+TEST_CASE("section", "[test macros]") {
+    snatch::registry mock_registry;
+
+    snatch::impl::test_case mock_case{
+        .id    = {"mock_test", "[mock_tag]", "mock_type"},
+        .func  = nullptr,
+        .state = snatch::impl::test_state::not_run};
+
+    std::vector<event_deep_copy> events;
+    auto report = [&](const snatch::registry&, const snatch::event::data& e) noexcept {
+        events.push_back(deep_copy(e));
+    };
+
+    mock_registry.report_callback = report;
+
+    SECTION("no section") {
+        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+            SNATCH_FAIL("trigger");
+        };
+
+        mock_registry.run(mock_case);
+        CHECK(get_num_failures(events) == 1u);
+        CHECK_NO_SECTION;
+    }
+
+    SECTION("single section") {
+        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+            SNATCH_SECTION("section 1") {
+                SNATCH_FAIL("trigger");
+            }
+        };
+
+        mock_registry.run(mock_case);
+        REQUIRE(get_num_failures(events) == 1u);
+        CHECK_SECTIONS("section 1");
+    }
+
+    SECTION("two sections") {
+        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+            SNATCH_SECTION("section 1") {
+                SNATCH_FAIL("trigger1");
+            }
+            SNATCH_SECTION("section 2") {
+                SNATCH_FAIL("trigger2");
+            }
+        };
+
+        mock_registry.run(mock_case);
+
+        REQUIRE(get_num_failures(events) == 2u);
+        CHECK_SECTIONS_FOR_FAILURE(0u, "section 1");
+        CHECK_SECTIONS_FOR_FAILURE(1u, "section 2");
+    }
+
+    SECTION("nested sections") {
+        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+            SNATCH_SECTION("section 1") {
+                SNATCH_FAIL_CHECK("trigger1");
+                SNATCH_SECTION("section 1.1") {
+                    SNATCH_FAIL_CHECK("trigger2");
+                }
+            }
+        };
+
+        mock_registry.run(mock_case);
+
+        REQUIRE(get_num_failures(events) == 2u);
+        CHECK_SECTIONS_FOR_FAILURE(0u, "section 1");
+        CHECK_SECTIONS_FOR_FAILURE(1u, "section 1", "section 1.1");
+    }
+
+    SECTION("nested sections abort early") {
+        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+            SNATCH_SECTION("section 1") {
+                SNATCH_FAIL("trigger1");
+                SNATCH_SECTION("section 1.1") {
+                    SNATCH_FAIL_CHECK("trigger2");
+                }
+            }
+        };
+
+        mock_registry.run(mock_case);
+
+        REQUIRE(get_num_failures(events) == 1u);
+        CHECK_SECTIONS("section 1");
+    }
+
+    SECTION("nested sections varying depth") {
+        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+            SNATCH_SECTION("section 1") {
+                SNATCH_SECTION("section 1.1") {}
+                SNATCH_SECTION("section 1.2") {
+                    SNATCH_FAIL_CHECK("trigger");
+                }
+                SNATCH_SECTION("section 1.3") {
+                    SNATCH_SECTION("section 1.3.1") {
+                        SNATCH_FAIL_CHECK("trigger");
+                    }
+                }
+                SNATCH_SECTION("section 1.3") {}
+            }
+            SNATCH_SECTION("section 2") {
+                SNATCH_SECTION("section 2.1") {
+                    SNATCH_FAIL_CHECK("trigger");
+                }
+                SNATCH_FAIL_CHECK("trigger");
+            }
+            SNATCH_SECTION("section 3") {
+                SNATCH_FAIL_CHECK("trigger");
+            }
+        };
+
+        mock_registry.run(mock_case);
+
+        REQUIRE(get_num_failures(events) == 5u);
+        CHECK_SECTIONS_FOR_FAILURE(0u, "section 1", "section 1.2");
+        CHECK_SECTIONS_FOR_FAILURE(1u, "section 1", "section 1.3", "section 1.3.1");
+        CHECK_SECTIONS_FOR_FAILURE(2u, "section 2", "section 2.1");
+        CHECK_SECTIONS_FOR_FAILURE(3u, "section 2");
+        CHECK_SECTIONS_FOR_FAILURE(4u, "section 3");
+    }
+};
+
+TEST_CASE("section readme example", "[test macros]") {
+    snatch::registry mock_registry;
+
+    snatch::impl::test_case mock_case{
+        .id    = {"mock_test", "[mock_tag]", "mock_type"},
+        .func  = nullptr,
+        .state = snatch::impl::test_state::not_run};
+
+    snatch::small_string<32> events;
+
+    auto print = [&](std::string_view s) noexcept {
+        if (!events.empty()) {
+            append_or_truncate(events, "|", s);
+        } else {
+            append_or_truncate(events, s);
+        }
+    };
+
+    mock_registry.print_callback = print;
+
+    mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        SNATCH_CURRENT_TEST.reg.print("S");
+
+        SECTION("first section") {
+            SNATCH_CURRENT_TEST.reg.print("1");
+        }
+        SECTION("second section") {
+            SNATCH_CURRENT_TEST.reg.print("2");
+        }
+        SECTION("third section") {
+            SNATCH_CURRENT_TEST.reg.print("3");
+            SECTION("nested section 1") {
+                SNATCH_CURRENT_TEST.reg.print("3.1");
+            }
+            SECTION("nested section 2") {
+                SNATCH_CURRENT_TEST.reg.print("3.2");
+            }
+        }
+
+        SNATCH_CURRENT_TEST.reg.print("E");
+    };
+
+    mock_registry.run(mock_case);
+
+    CHECK(events == "S|1|E|S|2|E|S|3|3.1|E|S|3|3.2|E"sv);
+};

--- a/tests/runtime_tests/section.cpp
+++ b/tests/runtime_tests/section.cpp
@@ -151,18 +151,18 @@ TEST_CASE("section readme example", "[test macros]") {
     mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
         SNATCH_CURRENT_TEST.reg.print("S");
 
-        SECTION("first section") {
+        SNATCH_SECTION("first section") {
             SNATCH_CURRENT_TEST.reg.print("1");
         }
-        SECTION("second section") {
+        SNATCH_SECTION("second section") {
             SNATCH_CURRENT_TEST.reg.print("2");
         }
-        SECTION("third section") {
+        SNATCH_SECTION("third section") {
             SNATCH_CURRENT_TEST.reg.print("3");
-            SECTION("nested section 1") {
+            SNATCH_SECTION("nested section 1") {
                 SNATCH_CURRENT_TEST.reg.print("3.1");
             }
-            SECTION("nested section 2") {
+            SNATCH_SECTION("nested section 2") {
                 SNATCH_CURRENT_TEST.reg.print("3.2");
             }
         }

--- a/tests/runtime_tests/section.cpp
+++ b/tests/runtime_tests/section.cpp
@@ -10,44 +10,32 @@ SNATCH_WARNING_PUSH
 SNATCH_WARNING_DISABLE_UNREACHABLE
 
 TEST_CASE("section", "[test macros]") {
-    snatch::registry mock_registry;
-
-    snatch::impl::test_case mock_case{
-        .id    = {"mock_test", "[mock_tag]", "mock_type"},
-        .func  = nullptr,
-        .state = snatch::impl::test_state::not_run};
-
-    std::vector<event_deep_copy> events;
-    auto report = [&](const snatch::registry&, const snatch::event::data& e) noexcept {
-        events.push_back(deep_copy(e));
-    };
-
-    mock_registry.report_callback = report;
+    mock_framework framework;
 
     SECTION("no section") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             SNATCH_FAIL_CHECK("trigger");
         };
 
-        mock_registry.run(mock_case);
-        CHECK(get_num_failures(events) == 1u);
+        framework.run_test();
+        CHECK(framework.get_num_failures() == 1u);
         CHECK_NO_SECTION;
     }
 
     SECTION("single section") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             SNATCH_SECTION("section 1") {
                 SNATCH_FAIL_CHECK("trigger");
             }
         };
 
-        mock_registry.run(mock_case);
-        REQUIRE(get_num_failures(events) == 1u);
+        framework.run_test();
+        REQUIRE(framework.get_num_failures() == 1u);
         CHECK_SECTIONS("section 1");
     }
 
     SECTION("two sections") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             SNATCH_SECTION("section 1") {
                 SNATCH_FAIL_CHECK("trigger1");
             }
@@ -56,15 +44,15 @@ TEST_CASE("section", "[test macros]") {
             }
         };
 
-        mock_registry.run(mock_case);
+        framework.run_test();
 
-        REQUIRE(get_num_failures(events) == 2u);
+        REQUIRE(framework.get_num_failures() == 2u);
         CHECK_SECTIONS_FOR_FAILURE(0u, "section 1");
         CHECK_SECTIONS_FOR_FAILURE(1u, "section 2");
     }
 
     SECTION("nested sections") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             SNATCH_SECTION("section 1") {
                 SNATCH_FAIL_CHECK("trigger1");
                 SNATCH_SECTION("section 1.1") {
@@ -73,15 +61,15 @@ TEST_CASE("section", "[test macros]") {
             }
         };
 
-        mock_registry.run(mock_case);
+        framework.run_test();
 
-        REQUIRE(get_num_failures(events) == 2u);
+        REQUIRE(framework.get_num_failures() == 2u);
         CHECK_SECTIONS_FOR_FAILURE(0u, "section 1");
         CHECK_SECTIONS_FOR_FAILURE(1u, "section 1", "section 1.1");
     }
 
     SECTION("nested sections abort early") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             SNATCH_SECTION("section 1") {
                 SNATCH_FAIL("trigger1");
                 SNATCH_SECTION("section 1.1") {
@@ -93,14 +81,14 @@ TEST_CASE("section", "[test macros]") {
             }
         };
 
-        mock_registry.run(mock_case);
+        framework.run_test();
 
-        REQUIRE(get_num_failures(events) == 1u);
+        REQUIRE(framework.get_num_failures() == 1u);
         CHECK_SECTIONS("section 1");
     }
 
     SECTION("nested sections std::exception throw") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             SNATCH_SECTION("section 1") {
                 throw std::runtime_error("no can do");
                 SNATCH_SECTION("section 1.1") {
@@ -112,14 +100,14 @@ TEST_CASE("section", "[test macros]") {
             }
         };
 
-        mock_registry.run(mock_case);
+        framework.run_test();
 
-        REQUIRE(get_num_failures(events) == 1u);
+        REQUIRE(framework.get_num_failures() == 1u);
         CHECK_NO_SECTION;
     }
 
     SECTION("nested sections unknown exception throw") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             SNATCH_SECTION("section 1") {
                 throw 1;
                 SNATCH_SECTION("section 1.1") {
@@ -131,14 +119,14 @@ TEST_CASE("section", "[test macros]") {
             }
         };
 
-        mock_registry.run(mock_case);
+        framework.run_test();
 
-        REQUIRE(get_num_failures(events) == 1u);
+        REQUIRE(framework.get_num_failures() == 1u);
         CHECK_NO_SECTION;
     }
 
     SECTION("nested sections varying depth") {
-        mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
             SNATCH_SECTION("section 1") {
                 SNATCH_SECTION("section 1.1") {}
                 SNATCH_SECTION("section 1.2") {
@@ -162,9 +150,9 @@ TEST_CASE("section", "[test macros]") {
             }
         };
 
-        mock_registry.run(mock_case);
+        framework.run_test();
 
-        REQUIRE(get_num_failures(events) == 5u);
+        REQUIRE(framework.get_num_failures() == 5u);
         CHECK_SECTIONS_FOR_FAILURE(0u, "section 1", "section 1.2");
         CHECK_SECTIONS_FOR_FAILURE(1u, "section 1", "section 1.3", "section 1.3.1");
         CHECK_SECTIONS_FOR_FAILURE(2u, "section 2", "section 2.1");
@@ -176,12 +164,7 @@ TEST_CASE("section", "[test macros]") {
 SNATCH_WARNING_POP
 
 TEST_CASE("section readme example", "[test macros]") {
-    snatch::registry mock_registry;
-
-    snatch::impl::test_case mock_case{
-        .id    = {"mock_test", "[mock_tag]", "mock_type"},
-        .func  = nullptr,
-        .state = snatch::impl::test_state::not_run};
+    mock_framework framework;
 
     snatch::small_string<32> events;
 
@@ -193,9 +176,10 @@ TEST_CASE("section readme example", "[test macros]") {
         }
     };
 
-    mock_registry.print_callback = print;
+    framework.registry.print_callback  = print;
+    framework.registry.report_callback = {};
 
-    mock_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+    framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
         SNATCH_CURRENT_TEST.reg.print("S");
 
         SNATCH_SECTION("first section") {
@@ -217,7 +201,7 @@ TEST_CASE("section readme example", "[test macros]") {
         SNATCH_CURRENT_TEST.reg.print("E");
     };
 
-    mock_registry.run(mock_case);
+    framework.run_test();
 
     CHECK(events == "S|1|E|S|2|E|S|3|3.1|E|S|3|3.2|E"sv);
 };

--- a/tests/runtime_tests/skip.cpp
+++ b/tests/runtime_tests/skip.cpp
@@ -29,6 +29,32 @@ TEST_CASE("skip", "[test macros]") {
         framework.run_test();
         CHECK(framework.get_num_skips() == 1u);
     }
+
+    SECTION("skip failure") {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+            SNATCH_SKIP("hello");
+            SNATCH_FAIL_CHECK("trigger");
+        };
+
+        framework.run_test();
+        CHECK(framework.get_num_skips() == 1u);
+        CHECK(framework.get_num_failures() == 0u);
+    }
+
+    SECTION("skip section") {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+            SNATCH_SECTION("section 1") {
+                SNATCH_SKIP("hello");
+            }
+            SNATCH_SECTION("section 2") {
+                SNATCH_FAIL_CHECK("trigger");
+            }
+        };
+
+        framework.run_test();
+        CHECK(framework.get_num_skips() == 1u);
+        CHECK(framework.get_num_failures() == 0u);
+    }
 };
 
 SNATCH_WARNING_POP

--- a/tests/runtime_tests/skip.cpp
+++ b/tests/runtime_tests/skip.cpp
@@ -1,0 +1,34 @@
+#include "testing.hpp"
+#include "testing_event.hpp"
+
+#include <stdexcept>
+#include <string>
+
+using namespace std::literals;
+
+SNATCH_WARNING_PUSH
+SNATCH_WARNING_DISABLE_UNREACHABLE
+
+TEST_CASE("skip", "[test macros]") {
+    mock_framework framework;
+
+    SECTION("no skip") {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+            SNATCH_FAIL_CHECK("trigger");
+        };
+
+        framework.run_test();
+        CHECK(framework.get_num_skips() == 0u);
+    }
+
+    SECTION("only skip") {
+        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+            SNATCH_SKIP("hello");
+        };
+
+        framework.run_test();
+        CHECK(framework.get_num_skips() == 1u);
+    }
+};
+
+SNATCH_WARNING_POP

--- a/tests/testing.hpp
+++ b/tests/testing.hpp
@@ -20,6 +20,7 @@
 #    define TEST_CASE(name, tags) DOCTEST_TEST_CASE(tags " " name)
 #    define TEMPLATE_TEST_CASE(name, tags, ...)                                                    \
         DOCTEST_TEST_CASE_TEMPLATE(tags " " name, TestType, __VA_ARGS__)
+#    define SKIP(message) return
 
 #    include <ostream>
 #endif

--- a/tests/testing.hpp
+++ b/tests/testing.hpp
@@ -23,3 +23,13 @@
 
 #    include <ostream>
 #endif
+
+#if defined(__clang__)
+#    define SNATCH_WARNING_DISABLE_UNREACHABLE
+#elif defined(__GNUC__)
+#    define SNATCH_WARNING_DISABLE_UNREACHABLE
+#elif defined(_MSC_VER)
+#    define SNATCH_WARNING_DISABLE_UNREACHABLE _Pragma("warning(disable: 4702)")
+#else
+#    define SNATCH_WARNING_DISABLE_UNREACHABLE
+#endif

--- a/tests/testing_event.cpp
+++ b/tests/testing_event.cpp
@@ -5,48 +5,29 @@
 
 #include <algorithm>
 
-event_deep_copy deep_copy(const snatch::event::data& e) {
-    return std::visit(
-        snatch::overload{
-            [](const snatch::event::assertion_failed& a) {
-                event_deep_copy c;
-                c.event_type = event_deep_copy::type::assertion_failed;
-                append_or_truncate(c.test_id_name, a.id.name);
-                append_or_truncate(c.test_id_tags, a.id.tags);
-                append_or_truncate(c.test_id_type, a.id.type);
-                append_or_truncate(c.location_file, a.location.file);
-                c.location_line = a.location.line;
-                append_or_truncate(c.message, a.message);
-                for (const auto& ac : a.captures) {
-                    c.captures.push_back(ac);
-                }
-                for (const auto& as : a.sections) {
-                    c.sections.push_back(as.name);
-                }
-                return c;
-            },
-            [](const snatch::event::test_case_started& s) {
-                event_deep_copy c;
-                c.event_type = event_deep_copy::type::test_case_started;
-                append_or_truncate(c.test_id_name, s.id.name);
-                append_or_truncate(c.test_id_tags, s.id.tags);
-                append_or_truncate(c.test_id_type, s.id.type);
-                return c;
-            },
-            [](const snatch::event::test_case_ended& s) {
-                event_deep_copy c;
-                c.event_type = event_deep_copy::type::test_case_ended;
-                append_or_truncate(c.test_id_name, s.id.name);
-                append_or_truncate(c.test_id_tags, s.id.tags);
-                append_or_truncate(c.test_id_type, s.id.type);
-                return c;
-            },
-            [](const auto&) -> event_deep_copy { snatch::terminate_with("event not handled"); }},
-        e);
+namespace {
+template<typename T>
+void copy_test_case_id(event_deep_copy& c, const T& e) {
+    append_or_truncate(c.test_id_name, e.id.name);
+    append_or_truncate(c.test_id_tags, e.id.tags);
+    append_or_truncate(c.test_id_type, e.id.type);
+}
+
+template<typename T>
+void copy_full_location(event_deep_copy& c, const T& e) {
+    append_or_truncate(c.location_file, e.location.file);
+    c.location_line = e.location.line;
+    append_or_truncate(c.message, e.message);
+    for (const auto& ec : e.captures) {
+        c.captures.push_back(ec);
+    }
+    for (const auto& es : e.sections) {
+        c.sections.push_back(es.name);
+    }
 }
 
 std::optional<event_deep_copy>
-get_failure_event(const std::vector<event_deep_copy>& events, std::size_t id) {
+get_event(const std::vector<event_deep_copy>& events, event_deep_copy::type type, std::size_t id) {
     auto iter  = events.cbegin();
     bool first = true;
 
@@ -58,9 +39,8 @@ get_failure_event(const std::vector<event_deep_copy>& events, std::size_t id) {
 
         first = false;
 
-        iter = std::find_if(iter, events.cend(), [](const event_deep_copy& e) {
-            return e.event_type == event_deep_copy::type::assertion_failed;
-        });
+        iter = std::find_if(
+            iter, events.cend(), [&](const event_deep_copy& e) { return e.event_type == type; });
     } while (id != 0);
 
     if (iter == events.cend()) {
@@ -70,32 +50,73 @@ get_failure_event(const std::vector<event_deep_copy>& events, std::size_t id) {
     }
 }
 
-std::size_t get_num_runs(const std::vector<event_deep_copy>& events) {
-    return std::count_if(events.cbegin(), events.cend(), [](const event_deep_copy& e) {
-        return e.event_type == event_deep_copy::type::test_case_ended;
+std::size_t count_events(const std::vector<event_deep_copy>& events, event_deep_copy::type type) {
+    return std::count_if(events.cbegin(), events.cend(), [&](const event_deep_copy& e) {
+        return e.event_type == type;
     });
 }
+} // namespace
 
-std::size_t get_num_failures(const std::vector<event_deep_copy>& events) {
-    return std::count_if(events.cbegin(), events.cend(), [](const event_deep_copy& e) {
-        return e.event_type == event_deep_copy::type::assertion_failed;
-    });
+event_deep_copy deep_copy(const snatch::event::data& e) {
+    return std::visit(
+        snatch::overload{
+            [](const snatch::event::assertion_failed& a) {
+                event_deep_copy c;
+                c.event_type = event_deep_copy::type::assertion_failed;
+                copy_test_case_id(c, a);
+                copy_full_location(c, a);
+                return c;
+            },
+            [](const snatch::event::test_case_started& s) {
+                event_deep_copy c;
+                c.event_type = event_deep_copy::type::test_case_started;
+                copy_test_case_id(c, s);
+                return c;
+            },
+            [](const snatch::event::test_case_ended& s) {
+                event_deep_copy c;
+                c.event_type = event_deep_copy::type::test_case_ended;
+                copy_test_case_id(c, s);
+                return c;
+            },
+            [](const snatch::event::test_case_skipped& s) {
+                event_deep_copy c;
+                c.event_type = event_deep_copy::type::test_case_skipped;
+                copy_full_location(c, s);
+                return c;
+            },
+            [](const auto&) -> event_deep_copy { snatch::terminate_with("event not handled"); }},
+        e);
 }
 
-void pop_first_run(std::vector<event_deep_copy>& events) {
-    auto iter = std::find_if(events.cbegin(), events.cend(), [](const event_deep_copy& e) {
-        return e.event_type == event_deep_copy::type::test_case_ended;
-    });
-
-    events.erase(events.begin(), iter);
+mock_framework::mock_framework() {
+    registry.report_callback = {*this, snatch::constant<&mock_framework::report>{}};
 }
 
-void pop_first_failure(std::vector<event_deep_copy>& events) {
-    auto iter = std::find_if(events.cbegin(), events.cend(), [](const event_deep_copy& e) {
-        return e.event_type == event_deep_copy::type::assertion_failed;
-    });
+void mock_framework::report(const snatch::registry&, const snatch::event::data& e) noexcept {
+    events.push_back(deep_copy(e));
+}
 
-    if (iter != events.end()) {
-        events.erase(iter);
-    }
+void mock_framework::run_test() {
+    registry.run(test_case);
+}
+
+std::optional<event_deep_copy> mock_framework::get_failure_event(std::size_t id) const {
+    return get_event(events, event_deep_copy::type::assertion_failed, id);
+}
+
+std::optional<event_deep_copy> mock_framework::get_skip_event() const {
+    return get_event(events, event_deep_copy::type::test_case_skipped, 0u);
+}
+
+std::size_t mock_framework::get_num_runs() const {
+    return count_events(events, event_deep_copy::type::test_case_ended);
+}
+
+std::size_t mock_framework::get_num_failures() const {
+    return count_events(events, event_deep_copy::type::assertion_failed);
+}
+
+std::size_t mock_framework::get_num_skips() const {
+    return count_events(events, event_deep_copy::type::test_case_skipped);
 }

--- a/tests/testing_event.cpp
+++ b/tests/testing_event.cpp
@@ -1,0 +1,101 @@
+// clang-format off
+#include "testing.hpp"
+#include "testing_event.hpp"
+// clang-format on
+
+#include <algorithm>
+
+event_deep_copy deep_copy(const snatch::event::data& e) {
+    return std::visit(
+        snatch::overload{
+            [](const snatch::event::assertion_failed& a) {
+                event_deep_copy c;
+                c.event_type = event_deep_copy::type::assertion_failed;
+                append_or_truncate(c.test_id_name, a.id.name);
+                append_or_truncate(c.test_id_tags, a.id.tags);
+                append_or_truncate(c.test_id_type, a.id.type);
+                append_or_truncate(c.location_file, a.location.file);
+                c.location_line = a.location.line;
+                append_or_truncate(c.message, a.message);
+                for (const auto& ac : a.captures) {
+                    c.captures.push_back(ac);
+                }
+                for (const auto& as : a.sections) {
+                    c.sections.push_back(as.name);
+                }
+                return c;
+            },
+            [](const snatch::event::test_case_started& s) {
+                event_deep_copy c;
+                c.event_type = event_deep_copy::type::test_case_started;
+                append_or_truncate(c.test_id_name, s.id.name);
+                append_or_truncate(c.test_id_tags, s.id.tags);
+                append_or_truncate(c.test_id_type, s.id.type);
+                return c;
+            },
+            [](const snatch::event::test_case_ended& s) {
+                event_deep_copy c;
+                c.event_type = event_deep_copy::type::test_case_ended;
+                append_or_truncate(c.test_id_name, s.id.name);
+                append_or_truncate(c.test_id_tags, s.id.tags);
+                append_or_truncate(c.test_id_type, s.id.type);
+                return c;
+            },
+            [](const auto&) -> event_deep_copy { snatch::terminate_with("event not handled"); }},
+        e);
+}
+
+std::optional<event_deep_copy>
+get_failure_event(const std::vector<event_deep_copy>& events, std::size_t id) {
+    auto iter  = events.cbegin();
+    bool first = true;
+
+    do {
+        if (!first) {
+            ++iter;
+            --id;
+        }
+
+        first = false;
+
+        iter = std::find_if(iter, events.cend(), [](const event_deep_copy& e) {
+            return e.event_type == event_deep_copy::type::assertion_failed;
+        });
+    } while (id != 0);
+
+    if (iter == events.cend()) {
+        return {};
+    } else {
+        return *iter;
+    }
+}
+
+std::size_t get_num_runs(const std::vector<event_deep_copy>& events) {
+    return std::count_if(events.cbegin(), events.cend(), [](const event_deep_copy& e) {
+        return e.event_type == event_deep_copy::type::test_case_ended;
+    });
+}
+
+std::size_t get_num_failures(const std::vector<event_deep_copy>& events) {
+    return std::count_if(events.cbegin(), events.cend(), [](const event_deep_copy& e) {
+        return e.event_type == event_deep_copy::type::assertion_failed;
+    });
+}
+
+void pop_first_run(std::vector<event_deep_copy>& events) {
+    auto iter = std::find_if(events.cbegin(), events.cend(), [](const event_deep_copy& e) {
+        return e.event_type == event_deep_copy::type::test_case_ended;
+    });
+
+    events.erase(events.begin(), iter);
+}
+
+void pop_first_failure(std::vector<event_deep_copy>& events) {
+    auto iter = std::find_if(events.cbegin(), events.cend(), [](const event_deep_copy& e) {
+        return e.event_type == event_deep_copy::type::assertion_failed;
+    });
+
+    if (iter != events.end()) {
+        events.erase(iter);
+    }
+}

--- a/tests/testing_event.hpp
+++ b/tests/testing_event.hpp
@@ -1,0 +1,64 @@
+namespace {
+struct event_deep_copy {
+    enum class type { unknown, test_case_started, test_case_ended, assertion_failed };
+
+    type event_type = type::unknown;
+
+    snatch::small_string<snatch::max_test_name_length> test_id_name;
+    snatch::small_string<snatch::max_test_name_length> test_id_tags;
+    snatch::small_string<snatch::max_test_name_length> test_id_type;
+
+    snatch::small_string<snatch::max_message_length> location_file;
+    std::size_t                                      location_line = 0u;
+
+    snatch::small_string<snatch::max_message_length> message;
+    snatch::small_vector<snatch::small_string<snatch::max_message_length>, snatch::max_captures>
+        captures;
+};
+
+event_deep_copy deep_copy(const snatch::event::data& e) {
+    return std::visit(
+        snatch::overload{
+            [](const snatch::event::assertion_failed& a) {
+                event_deep_copy c;
+                c.event_type = event_deep_copy::type::assertion_failed;
+                append_or_truncate(c.test_id_name, a.id.name);
+                append_or_truncate(c.test_id_tags, a.id.tags);
+                append_or_truncate(c.test_id_type, a.id.type);
+                append_or_truncate(c.location_file, a.location.file);
+                c.location_line = a.location.line;
+                append_or_truncate(c.message, a.message);
+                for (const auto& ac : a.captures) {
+                    c.captures.push_back(ac);
+                }
+                return c;
+            },
+            [](const snatch::event::test_case_started& s) {
+                event_deep_copy c;
+                c.event_type = event_deep_copy::type::test_case_started;
+                append_or_truncate(c.test_id_name, s.id.name);
+                append_or_truncate(c.test_id_tags, s.id.tags);
+                append_or_truncate(c.test_id_type, s.id.type);
+                return c;
+            },
+            [](const snatch::event::test_case_ended& s) {
+                event_deep_copy c;
+                c.event_type = event_deep_copy::type::test_case_ended;
+                append_or_truncate(c.test_id_name, s.id.name);
+                append_or_truncate(c.test_id_tags, s.id.tags);
+                append_or_truncate(c.test_id_type, s.id.type);
+                return c;
+            },
+            [](const auto&) -> event_deep_copy { snatch::terminate_with("event not handled"); }},
+        e);
+}
+} // namespace
+
+#define CHECK_EVENT_TEST_ID(ACTUAL, EXPECTED)                                                      \
+    CHECK(ACTUAL.test_id_name == EXPECTED.name);                                                   \
+    CHECK(ACTUAL.test_id_tags == EXPECTED.tags);                                                   \
+    CHECK(ACTUAL.test_id_type == EXPECTED.type)
+
+#define CHECK_EVENT_LOCATION(ACTUAL, FILE, LINE)                                                   \
+    CHECK(ACTUAL.location_file == std::string_view(FILE));                                         \
+    CHECK(ACTUAL.location_line == LINE)


### PR DESCRIPTION
This PR does the following.

Other miscellaneous changes:
 - `snatch.hpp` now includes `snatch_config.hpp` to reduce the risk of mismatched configuration with implementation.
 - (docs) Added example CMake usage instructions.
 - (docs) Clarified what happens when a test with sections is aborted.
 - (tests) Added tests for `SECTION()`, `CAPTURE()`, `INFO()`, and `SKIP()`.
 - (CI) Let all tests run even if some failed.