### PR TITLE
Allow test macros in other functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,19 +33,12 @@ The goal of _snatch_ is to be a simple, cheap, non-invasive, and user-friendly t
 
 ## Features and limitations
 
- - No heap allocation from the testing framework, so memory leaks from your code can be detected precisely.
+ - No heap allocation from the testing framework, so heap allocations from your code can be tracked precisely.
  - Works with exceptions disabled, albeit with a minor limitation (see [Exceptions](#exceptions) below).
  - No external dependency; just pure C++20 with the STL.
- - Compiles tests at least 40% faster than other testing frameworks (see [Benchmark](#benchmark)).
+ - Compiles tests up to 40% faster than other testing frameworks (see [Benchmark](#benchmark)).
  - Defaults to reporting test results to the standard output, with coloring for readability, but test events can also be forwarded to a reporter callback for reporting to CI frameworks (Teamcity, ..., see [Reporters](#reporters)).
- - Limited subset of the [_Catch2_](https://github.com/catchorg/_Catch2_) API, including:
-   - Simple test cases with `TEST_CASE(name, tags)`.
-   - Typed test cases with `TEMPLATE_LIST_TEST_CASE(name, tags, types)` and  `TEMPLATE_TEST_CASE(name, tags, types...)`.
-   - Pretty-printing check macros: `REQUIRE(expr)`, `CHECK(expr)`, `REQUIRE_THAT(expr, matcher)`, `CHECK_THAT(expr, matcher)`, `FAIL(msg)`, `FAIL_CHECK(msg)`.
-   - Exception checking macros: `REQUIRE_THROWS_AS(expr, except)`, `CHECK_THROWS_AS(expr, except)`, `REQUIRE_THROWS_MATCHES(expr, exception, matcher)`, `CHECK_THROWS_MATCHES(expr, except, matcher)`.
-   - Nesting multiple tests in a single test case with `SECTION(name, description)`.
-   - Capturing context information to display on failure with `CAPTURE(vars...)` and `INFO(message)`.
-   - Optional `main()` with simple command-line API similar to _Catch2_.
+ - Limited subset of the [_Catch2_](https://github.com/catchorg/_Catch2_) API, see [Comparison with _Catch2_](#detailed-comparison-with-catch2).
  - Additional API not in _Catch2_, or different from _Catch2_:
    - Macro to mark a test as skipped: `SKIP(msg)`.
    - Matchers use a different API (see [Matchers](#matchers) below).
@@ -54,7 +47,6 @@ If you need features that are not in the list above, please use _Catch2_ or _doc
 
 Notable current limitations:
 
- - Test macros (`REQUIRE(...)`, etc.) may only be used inside the test body (or in lambdas defined in the test body), and cannot be used in other functions.
  - No fixtures, or set-up/tear-down helpers (`SECTION()` can be used to share set-up/tear-down logic).
  - No multi-threaded test execution.
 
@@ -677,7 +669,7 @@ By default, _snatch_ assumes exceptions are enabled, and uses them in two cases:
 If _snatch_ detects that exceptions are not available (or is configured with exceptions disabled, by setting `SNATCH_WITH_EXCEPTIONS` to `0`), then
 
  1. Test macros that check exceptions being thrown will not be defined.
- 2. `REQUIRE_*()` and `FAIL()` macros will simply use `return` to abort execution. As a consequence, if these macros are used inside lambda functions, they will only abort execution of the lambda and not of the actual test case. Therefore, these macros should only be used in the immediate body of the test case, or simply not at all.
+ 2. `REQUIRE_*()` and `FAIL()` macros will simply use `return` to abort execution. As a consequence, if these macros are used inside functions other than the test case function, they will only abort execution of the current function, and not of the actual test case. Therefore, these macros should only be used in the immediate body of the test case, or simply not at all.
 
 
 ### Header-only build

--- a/README.md
+++ b/README.md
@@ -184,20 +184,20 @@ Results for Debug builds:
 | Build framework | 1.7s     | 64s      | 2.0s      | 0s         |
 | Build tests     | 61s      | 86s      | 78s       | 109s       |
 | Build all       | 63s      | 150s     | 80s       | 109s       |
-| Run tests       | 16ms     | 83ms     | 60ms      | 20ms       |
+| Run tests       | 17ms     | 83ms     | 60ms      | 20ms       |
 | Library size    | 2.80MB   | 38.6MB   | 2.8MB     | 0MB        |
-| Executable size | 31.7MB   | 49.3MB   | 38.6MB    | 51.9MB     |
+| Executable size | 32.3MB   | 49.3MB   | 38.6MB    | 51.9MB     |
 
 Results for Release builds:
 
 | **Release**     | _snatch_ | _Catch2_ | _doctest_ | _Boost UT_ |
 |-----------------|----------|----------|-----------|------------|
 | Build framework | 2.5s     | 68s      | 3.6s      | 0s         |
-| Build tests     | 132s     | 264s     | 216s      | 281s       |
-| Build all       | 135s     | 332s     | 220s      | 281s       |
-| Run tests       | 9ms      | 31ms     | 36ms      | 10ms       |
+| Build tests     | 135s     | 264s     | 216s      | 281s       |
+| Build all       | 137s     | 332s     | 220s      | 281s       |
+| Run tests       | 10ms     | 31ms     | 36ms      | 10ms       |
 | Library size    | 0.62MB   | 2.6MB    | 0.39MB    | 0MB        |
-| Executable size | 9.3MB    | 17.4MB   | 15.2MB    | 11.3MB     |
+| Executable size | 9.8MB    | 17.4MB   | 15.2MB    | 11.3MB     |
 
 Notes:
  - No attempt was made to optimize each framework's configuration; the defaults were used. C++20 modules were not used.

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -797,7 +797,7 @@ test_run registry::run(test_case& test) noexcept {
             report_failure(state, {__FILE__, __LINE__}, "unhandled unknown exception caught");
         }
 #else
-        test.func(state);
+        test.func();
 #endif
 
         if (state.sections.levels.size() == 1) {

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -38,6 +38,8 @@ template<typename T>
 colored<T> make_colored(const T& t, bool with_color, color_t start) {
     return {t, with_color ? start : "", with_color ? color::reset : ""};
 }
+
+thread_local snatch::impl::test_run* thread_current_test = nullptr;
 } // namespace
 
 namespace {
@@ -222,6 +224,24 @@ void stdout_print(std::string_view message) noexcept {
     // TODO: replace this with std::print?
     std::printf("%.*s", static_cast<int>(message.length()), message.data());
 }
+
+test_run& get_current_test() noexcept {
+    test_run* current = thread_current_test;
+    if (current == nullptr) {
+        terminate_with("no test case is currently running on this thread");
+    }
+
+    return *current;
+}
+
+test_run* try_get_current_test() noexcept {
+    return thread_current_test;
+}
+
+void set_current_test(test_run* current) noexcept {
+    thread_current_test = current;
+}
+
 } // namespace snatch::impl
 
 namespace snatch::cli {
@@ -748,6 +768,11 @@ test_run registry::run(test_case& test) noexcept {
 #endif
     };
 
+    // Store previously running test, to restore it later.
+    // This should always be a null pointer, except when testing snatch itself.
+    test_run* previous_run = thread_current_test;
+    thread_current_test    = &state;
+
 #if SNATCH_WITH_TIMINGS
     using clock     = std::chrono::high_resolution_clock;
     auto time_start = clock::now();
@@ -762,7 +787,7 @@ test_run registry::run(test_case& test) noexcept {
 
 #if SNATCH_WITH_EXCEPTIONS
         try {
-            test.func(state);
+            test.func();
         } catch (const impl::abort_exception&) {
             // Test aborted, assume its state was already set accordingly.
         } catch (const std::exception& e) {
@@ -806,6 +831,8 @@ test_run registry::run(test_case& test) noexcept {
             make_colored(full_name, with_color, color::highlight1), "\n");
 #endif
     }
+
+    thread_current_test = previous_run;
 
     return state;
 }

--- a/tests/runtime_tests/capture.cpp
+++ b/tests/runtime_tests/capture.cpp
@@ -13,7 +13,7 @@ TEST_CASE("capture", "[test macros]") {
     framework.setup_reporter();
 
     SECTION("literal int") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             SNATCH_CAPTURE(1);
             SNATCH_FAIL("trigger");
         };
@@ -23,7 +23,7 @@ TEST_CASE("capture", "[test macros]") {
     }
 
     SECTION("literal string") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             SNATCH_CAPTURE("hello");
             SNATCH_FAIL("trigger");
         };
@@ -33,7 +33,7 @@ TEST_CASE("capture", "[test macros]") {
     }
 
     SECTION("variable int") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             int i = 1;
             SNATCH_CAPTURE(i);
             SNATCH_FAIL("trigger");
@@ -44,7 +44,7 @@ TEST_CASE("capture", "[test macros]") {
     }
 
     SECTION("variable string") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             std::string s = "hello";
             SNATCH_CAPTURE(s);
             SNATCH_FAIL("trigger");
@@ -55,7 +55,7 @@ TEST_CASE("capture", "[test macros]") {
     }
 
     SECTION("expression int") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             int i = 1;
             SNATCH_CAPTURE(2 * i + 1);
             SNATCH_FAIL("trigger");
@@ -66,7 +66,7 @@ TEST_CASE("capture", "[test macros]") {
     }
 
     SECTION("expression string") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             std::string s = "hello";
             SNATCH_CAPTURE(s + ", 'world' (string),)(");
             SNATCH_FAIL("trigger");
@@ -77,7 +77,7 @@ TEST_CASE("capture", "[test macros]") {
     }
 
     SECTION("expression function call & char") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             std::string s = "hel\"lo";
             SNATCH_CAPTURE(s.find_first_of('e'));
             SNATCH_CAPTURE(s.find_first_of('"'));
@@ -89,7 +89,7 @@ TEST_CASE("capture", "[test macros]") {
     }
 
     SECTION("two variables") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             int i = 1;
             int j = 2;
             SNATCH_CAPTURE(i, j);
@@ -101,7 +101,7 @@ TEST_CASE("capture", "[test macros]") {
     }
 
     SECTION("three variables different types") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             int         i = 1;
             int         j = 2;
             std::string s = "hello";
@@ -114,7 +114,7 @@ TEST_CASE("capture", "[test macros]") {
     }
 
     SECTION("scoped out") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             {
                 int i = 1;
                 SNATCH_CAPTURE(i);
@@ -127,7 +127,7 @@ TEST_CASE("capture", "[test macros]") {
     }
 
     SECTION("scoped out multiple capture") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             int i = 1;
             SNATCH_CAPTURE(i);
 
@@ -144,7 +144,7 @@ TEST_CASE("capture", "[test macros]") {
     }
 
     SECTION("multiple failures") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             int i = 1;
             SNATCH_CAPTURE(i);
             SNATCH_FAIL_CHECK("trigger1");
@@ -158,7 +158,7 @@ TEST_CASE("capture", "[test macros]") {
     }
 
     SECTION("multiple failures interleaved") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             int i = 1;
             SNATCH_CAPTURE(i);
             SNATCH_FAIL_CHECK("trigger1");
@@ -178,7 +178,7 @@ TEST_CASE("info", "[test macros]") {
     framework.setup_reporter();
 
     SECTION("literal int") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             SNATCH_INFO(1);
             SNATCH_FAIL("trigger");
         };
@@ -188,7 +188,7 @@ TEST_CASE("info", "[test macros]") {
     }
 
     SECTION("literal string") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             SNATCH_INFO("hello");
             SNATCH_FAIL("trigger");
         };
@@ -198,7 +198,7 @@ TEST_CASE("info", "[test macros]") {
     }
 
     SECTION("variable int") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             int i = 1;
             SNATCH_INFO(i);
             SNATCH_FAIL("trigger");
@@ -209,7 +209,7 @@ TEST_CASE("info", "[test macros]") {
     }
 
     SECTION("variable string") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             std::string s = "hello";
             SNATCH_INFO(s);
             SNATCH_FAIL("trigger");
@@ -220,7 +220,7 @@ TEST_CASE("info", "[test macros]") {
     }
 
     SECTION("expression int") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             int i = 1;
             SNATCH_INFO(2 * i + 1);
             SNATCH_FAIL("trigger");
@@ -231,7 +231,7 @@ TEST_CASE("info", "[test macros]") {
     }
 
     SECTION("expression string") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             std::string s = "hello";
             SNATCH_INFO(s + ", 'world'");
             SNATCH_FAIL("trigger");
@@ -242,7 +242,7 @@ TEST_CASE("info", "[test macros]") {
     }
 
     SECTION("multiple") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             int         i = 1;
             int         j = 2;
             std::string s = "hello";
@@ -255,7 +255,7 @@ TEST_CASE("info", "[test macros]") {
     }
 
     SECTION("scoped out") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             {
                 int i = 1;
                 SNATCH_INFO(i);
@@ -268,7 +268,7 @@ TEST_CASE("info", "[test macros]") {
     }
 
     SECTION("scoped out multiple") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             int i = 1;
             SNATCH_INFO(i);
 
@@ -285,7 +285,7 @@ TEST_CASE("info", "[test macros]") {
     }
 
     SECTION("multiple failures") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             int i = 1;
             SNATCH_INFO(i);
             SNATCH_FAIL_CHECK("trigger1");
@@ -299,7 +299,7 @@ TEST_CASE("info", "[test macros]") {
     }
 
     SECTION("multiple failures interleaved") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             int i = 1;
             SNATCH_INFO(i);
             SNATCH_FAIL_CHECK("trigger1");
@@ -314,7 +314,7 @@ TEST_CASE("info", "[test macros]") {
     }
 
     SECTION("mixed with capture") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             int i = 1;
             SNATCH_INFO(i);
             SNATCH_CAPTURE(i);

--- a/tests/runtime_tests/registry.cpp
+++ b/tests/runtime_tests/registry.cpp
@@ -19,9 +19,7 @@ TEST_CASE("add regular test", "[registry]") {
     mock_framework framework;
 
     test_called                                        = false;
-    framework.registry.add("how many lights", "[tag]") = [](snatch::impl::test_run&) {
-        test_called = true;
-    };
+    framework.registry.add("how many lights", "[tag]") = []() { test_called = true; };
 
     REQUIRE(framework.get_num_registered_tests() == 1u);
 
@@ -65,7 +63,7 @@ TEST_CASE("add template test", "[registry]") {
 
         if (with_type_list) {
             framework.registry.add_with_type_list<snatch::type_list<int, float>>(
-                "how many lights", "[tag]") = []<typename T>(snatch::impl::test_run&) {
+                "how many lights", "[tag]") = []<typename T>() {
                 if constexpr (std::is_same_v<T, int>) {
                     test_called_int = true;
                 } else if constexpr (std::is_same_v<T, float>) {
@@ -76,7 +74,7 @@ TEST_CASE("add template test", "[registry]") {
             };
         } else {
             framework.registry.add_with_types<int, float>("how many lights", "[tag]") =
-                []<typename T>(snatch::impl::test_run&) {
+                []<typename T>() {
                     if constexpr (std::is_same_v<T, int>) {
                         test_called_int = true;
                     } else if constexpr (std::is_same_v<T, float>) {
@@ -159,13 +157,11 @@ SNATCH_WARNING_DISABLE_UNREACHABLE
 TEST_CASE("report FAIL regular", "[registry]") {
     mock_framework framework;
 
-#define SNATCH_CURRENT_TEST mock_test
-    framework.registry.add("how many lights", "[tag]") = [](snatch::impl::test_run& mock_test) {
+    framework.registry.add("how many lights", "[tag]") = []() {
         // clang-format off
         failure_line = __LINE__; SNATCH_FAIL("there are four lights");
         // clang-format on
     };
-#undef SNATCH_CURRENT_TEST
 
     auto& test = *framework.registry.begin();
 
@@ -195,14 +191,11 @@ TEST_CASE("report FAIL regular", "[registry]") {
 TEST_CASE("report FAIL template", "[registry]") {
     mock_framework framework;
 
-#define SNATCH_CURRENT_TEST mock_test
-    framework.registry.add_with_types<int>("how many lights", "[tag]") =
-        []<typename TestType>(snatch::impl::test_run& mock_test) {
-            // clang-format off
+    framework.registry.add_with_types<int>("how many lights", "[tag]") = []<typename TestType>() {
+        // clang-format off
             failure_line = __LINE__; SNATCH_FAIL("there are four lights");
-            // clang-format on
-        };
-#undef SNATCH_CURRENT_TEST
+        // clang-format on
+    };
 
     auto& test = *framework.registry.begin();
 
@@ -233,15 +226,13 @@ TEST_CASE("report FAIL template", "[registry]") {
 TEST_CASE("report FAIL section", "[registry]") {
     mock_framework framework;
 
-#define SNATCH_CURRENT_TEST mock_test
-    framework.registry.add("how many lights", "[tag]") = [](snatch::impl::test_run& mock_test) {
+    framework.registry.add("how many lights", "[tag]") = []() {
         SNATCH_SECTION("ask nicely") {
             // clang-format off
             failure_line = __LINE__; SNATCH_FAIL("there are four lights");
             // clang-format on
         }
     };
-#undef SNATCH_CURRENT_TEST
 
     auto& test = *framework.registry.begin();
 
@@ -274,15 +265,13 @@ TEST_CASE("report FAIL section", "[registry]") {
 TEST_CASE("report FAIL capture", "[registry]") {
     mock_framework framework;
 
-#define SNATCH_CURRENT_TEST mock_test
-    framework.registry.add("how many lights", "[tag]") = [](snatch::impl::test_run& mock_test) {
+    framework.registry.add("how many lights", "[tag]") = []() {
         int number_of_lights = 3;
         SNATCH_CAPTURE(number_of_lights);
         // clang-format off
         failure_line = __LINE__; SNATCH_FAIL("there are four lights");
         // clang-format on
     };
-#undef SNATCH_CURRENT_TEST
 
     auto& test = *framework.registry.begin();
 
@@ -315,14 +304,12 @@ TEST_CASE("report FAIL capture", "[registry]") {
 TEST_CASE("report REQUIRE", "[registry]") {
     mock_framework framework;
 
-#define SNATCH_CURRENT_TEST mock_test
-    framework.registry.add("how many lights", "[tag]") = [](snatch::impl::test_run& mock_test) {
+    framework.registry.add("how many lights", "[tag]") = []() {
         int number_of_lights = 4;
         // clang-format off
         failure_line = __LINE__; SNATCH_REQUIRE(number_of_lights == 3);
         // clang-format on
     };
-#undef SNATCH_CURRENT_TEST
 
     auto& test = *framework.registry.begin();
 
@@ -346,14 +333,12 @@ TEST_CASE("report REQUIRE", "[registry]") {
 TEST_CASE("report REQUIRE_THROWS_AS", "[registry]") {
     mock_framework framework;
 
-#    define SNATCH_CURRENT_TEST mock_test
-    framework.registry.add("how many lights", "[tag]") = [](snatch::impl::test_run& mock_test) {
+    framework.registry.add("how many lights", "[tag]") = []() {
         auto ask_how_many_lights = [] { throw std::runtime_error{"there are four lights"}; };
         // clang-format off
         failure_line = __LINE__; SNATCH_REQUIRE_THROWS_AS(ask_how_many_lights(), std::logic_error);
         // clang-format on
     };
-#    undef SNATCH_CURRENT_TEST
 
     auto& test = *framework.registry.begin();
 
@@ -379,13 +364,11 @@ TEST_CASE("report REQUIRE_THROWS_AS", "[registry]") {
 TEST_CASE("report SKIP", "[registry]") {
     mock_framework framework;
 
-#define SNATCH_CURRENT_TEST mock_test
-    framework.registry.add("how many lights", "[tag]") = [](snatch::impl::test_run& mock_test) {
+    framework.registry.add("how many lights", "[tag]") = []() {
         // clang-format off
         failure_line = __LINE__; SNATCH_SKIP("there are four lights");
         // clang-format on
     };
-#undef SNATCH_CURRENT_TEST
 
     auto& test = *framework.registry.begin();
 
@@ -414,26 +397,20 @@ void register_tests(mock_framework& framework) {
     test_called_int       = false;
     test_called_float     = false;
 
-#define SNATCH_CURRENT_TEST mock_test
-    framework.registry.add("how are you", "[tag]") = [](snatch::impl::test_run&) {
-        test_called = true;
+    framework.registry.add("how are you", "[tag]") = []() { test_called = true; };
+
+    framework.registry.add("how many lights", "[tag][other_tag]") = []() {
+        test_called_other_tag = true;
+        SNATCH_FAIL_CHECK("there are four lights");
     };
 
-    framework.registry.add("how many lights", "[tag][other_tag]") =
-        [](snatch::impl::test_run& mock_test) {
-            test_called_other_tag = true;
-            SNATCH_FAIL_CHECK("there are four lights");
-        };
-
-    framework.registry.add("drink from the cup", "[tag][skipped]") =
-        [](snatch::impl::test_run& mock_test) {
-            test_called_skipped = true;
-            SNATCH_SKIP("not thirsty");
-        };
+    framework.registry.add("drink from the cup", "[tag][skipped]") = []() {
+        test_called_skipped = true;
+        SNATCH_SKIP("not thirsty");
+    };
 
     framework.registry.add_with_types<int, float>(
-        "how many templated lights",
-        "[tag][tag with spaces]") = []<typename T>(snatch::impl::test_run& mock_test) {
+        "how many templated lights", "[tag][tag with spaces]") = []<typename T>() {
         if constexpr (std::is_same_v<T, int>) {
             test_called_int = true;
             SNATCH_FAIL_CHECK("there are four lights (int)");
@@ -442,7 +419,6 @@ void register_tests(mock_framework& framework) {
             SNATCH_FAIL_CHECK("there are four lights (float)");
         }
     };
-#undef SNATCH_CURRENT_TEST
 }
 } // namespace
 

--- a/tests/runtime_tests/section.cpp
+++ b/tests/runtime_tests/section.cpp
@@ -14,9 +14,7 @@ TEST_CASE("section", "[test macros]") {
     framework.setup_reporter();
 
     SECTION("no section") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
-            SNATCH_FAIL_CHECK("trigger");
-        };
+        framework.test_case.func = []() { SNATCH_FAIL_CHECK("trigger"); };
 
         framework.run_test();
         CHECK(framework.get_num_failures() == 1u);
@@ -24,7 +22,7 @@ TEST_CASE("section", "[test macros]") {
     }
 
     SECTION("single section") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             SNATCH_SECTION("section 1") {
                 SNATCH_FAIL_CHECK("trigger");
             }
@@ -36,7 +34,7 @@ TEST_CASE("section", "[test macros]") {
     }
 
     SECTION("two sections") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             SNATCH_SECTION("section 1") {
                 SNATCH_FAIL_CHECK("trigger1");
             }
@@ -53,7 +51,7 @@ TEST_CASE("section", "[test macros]") {
     }
 
     SECTION("nested sections") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             SNATCH_SECTION("section 1") {
                 SNATCH_FAIL_CHECK("trigger1");
                 SNATCH_SECTION("section 1.1") {
@@ -70,7 +68,7 @@ TEST_CASE("section", "[test macros]") {
     }
 
     SECTION("nested sections abort early") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             SNATCH_SECTION("section 1") {
                 SNATCH_FAIL("trigger1");
                 SNATCH_SECTION("section 1.1") {
@@ -89,7 +87,7 @@ TEST_CASE("section", "[test macros]") {
     }
 
     SECTION("nested sections std::exception throw") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             SNATCH_SECTION("section 1") {
                 throw std::runtime_error("no can do");
                 SNATCH_SECTION("section 1.1") {
@@ -108,7 +106,7 @@ TEST_CASE("section", "[test macros]") {
     }
 
     SECTION("nested sections unknown exception throw") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             SNATCH_SECTION("section 1") {
                 throw 1;
                 SNATCH_SECTION("section 1.1") {
@@ -127,9 +125,10 @@ TEST_CASE("section", "[test macros]") {
     }
 
     SECTION("nested sections varying depth") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             SNATCH_SECTION("section 1") {
-                SNATCH_SECTION("section 1.1") {}
+                SNATCH_SECTION("section 1.1") {
+                }
                 SNATCH_SECTION("section 1.2") {
                     SNATCH_FAIL_CHECK("trigger");
                 }
@@ -138,7 +137,8 @@ TEST_CASE("section", "[test macros]") {
                         SNATCH_FAIL_CHECK("trigger");
                     }
                 }
-                SNATCH_SECTION("section 1.3") {}
+                SNATCH_SECTION("section 1.3") {
+                }
             }
             SNATCH_SECTION("section 2") {
                 SNATCH_SECTION("section 2.1") {
@@ -162,7 +162,7 @@ TEST_CASE("section", "[test macros]") {
     }
 
     SECTION("one section in a loop") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             for (std::size_t i = 0u; i < 5u; ++i) {
                 SNATCH_SECTION("section 1") {
                     SNATCH_FAIL_CHECK("trigger");
@@ -181,7 +181,7 @@ TEST_CASE("section", "[test macros]") {
     }
 
     SECTION("two sections in a loop") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             for (std::size_t i = 0u; i < 5u; ++i) {
                 SNATCH_SECTION("section 1") {
                     SNATCH_CHECK(i % 2u == 0u);
@@ -221,26 +221,28 @@ TEST_CASE("section readme example", "[test macros]") {
     framework.registry.print_callback  = print;
     framework.registry.report_callback = {};
 
-    framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
-        SNATCH_CURRENT_TEST.reg.print("S");
+    framework.test_case.func = []() {
+        auto& reg = snatch::impl::get_current_test().reg;
+
+        reg.print("S");
 
         SNATCH_SECTION("first section") {
-            SNATCH_CURRENT_TEST.reg.print("1");
+            reg.print("1");
         }
         SNATCH_SECTION("second section") {
-            SNATCH_CURRENT_TEST.reg.print("2");
+            reg.print("2");
         }
         SNATCH_SECTION("third section") {
-            SNATCH_CURRENT_TEST.reg.print("3");
+            reg.print("3");
             SNATCH_SECTION("nested section 1") {
-                SNATCH_CURRENT_TEST.reg.print("3.1");
+                reg.print("3.1");
             }
             SNATCH_SECTION("nested section 2") {
-                SNATCH_CURRENT_TEST.reg.print("3.2");
+                reg.print("3.2");
             }
         }
 
-        SNATCH_CURRENT_TEST.reg.print("E");
+        reg.print("E");
     };
 
     framework.run_test();

--- a/tests/runtime_tests/skip.cpp
+++ b/tests/runtime_tests/skip.cpp
@@ -11,25 +11,21 @@ TEST_CASE("skip", "[test macros]") {
     framework.setup_reporter();
 
     SECTION("no skip") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
-            SNATCH_FAIL_CHECK("trigger");
-        };
+        framework.test_case.func = []() { SNATCH_FAIL_CHECK("trigger"); };
 
         framework.run_test();
         CHECK(framework.get_num_skips() == 0u);
     }
 
     SECTION("only skip") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
-            SNATCH_SKIP("hello");
-        };
+        framework.test_case.func = []() { SNATCH_SKIP("hello"); };
 
         framework.run_test();
         CHECK(framework.get_num_skips() == 1u);
     }
 
     SECTION("skip failure") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             SNATCH_SKIP("hello");
             SNATCH_FAIL_CHECK("trigger");
         };
@@ -40,7 +36,7 @@ TEST_CASE("skip", "[test macros]") {
     }
 
     SECTION("skip section") {
-        framework.test_case.func = [](snatch::impl::test_run& SNATCH_CURRENT_TEST) {
+        framework.test_case.func = []() {
             SNATCH_SECTION("section 1") {
                 SNATCH_SKIP("hello");
             }


### PR DESCRIPTION
This PR changes the internal implementation of the test macros (`REQUIRE(...)` etc) so they refer to a `thread_local` instance of `test_run`, rather than rely on it being available in the current scope as `SNATCH_CURRENT_TEST` (which, previously, was provided as an argument of the test case). This allows using the test macros in other functions, not only in the immediate scope of the test case.

This has a small performance hit, which was deemed acceptable given the benefits.

Closes #31.