### PR TITLE
Add full `constexpr` support for `small_vector` and `small_string`

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,6 +22,10 @@ jobs:
         build-type:
         - Release
         - Debug
+        config:
+        - { name: Default, run-tests: true, flags: ""}
+        - { name: No timings, run-tests: false, flags: "-DSNATCH_WITH_TIMINGS=0"}
+        - { name: No exceptions, run-tests: false, flags: "-DSNATCH_WITH_EXCEPTIONS=0"}
 
     name: ${{matrix.platform.name}} ${{matrix.build-type}}
     runs-on: ${{matrix.platform.os}}
@@ -65,7 +69,7 @@ jobs:
     - name: Configure CMake
       shell: bash
       working-directory: ${{github.workspace}}/build
-      run: ${{matrix.platform.cmakepp}} cmake .. -DCMAKE_BUILD_TYPE=${{matrix.build-type}} ${{matrix.platform.flags}} -DSNATCH_DO_TEST=1 -DCMAKE_INSTALL_PREFIX=../install
+      run: ${{matrix.platform.cmakepp}} cmake .. -DCMAKE_BUILD_TYPE=${{matrix.build-type}} ${{matrix.platform.flags}} ${{matrix.config.flags}} -DSNATCH_DO_TEST=1 -DCMAKE_INSTALL_PREFIX=../install
 
     - name: Build
       shell: bash
@@ -76,39 +80,39 @@ jobs:
       shell: bash
       working-directory: ${{github.workspace}}/build
       # Run even if previous tests failed
-      if: always()
+      if: always() && matrix.config.run-tests
       run: cmake --build . --config ${{matrix.build-type}} --target snatch_runtime_tests_run
 
     - name: Test (with snatch)
       shell: bash
       working-directory: ${{github.workspace}}/build
       # Run even if previous tests failed
-      if: always()
+      if: always() && matrix.config.run-tests
       run: cmake --build . --config ${{matrix.build-type}} --target snatch_runtime_tests_self_run
 
     - name: Test header-only (with snatch)
       shell: bash
       working-directory: ${{github.workspace}}/build
       # Run even if previous tests failed
-      if: always()
+      if: always() && matrix.config.run-tests
       run: cmake --build . --config ${{matrix.build-type}} --target snatch_runtime_tests_self_header_only_run
 
     - name: Compute code coverage
-      if: runner.os == 'Linux' && matrix.platform.compiler == 'g++' && matrix.build-type == 'Debug'
+      if: runner.os == 'Linux' && matrix.platform.compiler == 'g++' && matrix.build-type == 'Debug' && matrix.config.name == 'Default'
       run: |
         gcov ${{github.workspace}}/build/tests/CMakeFiles/snatch_runtime_tests.dir/runtime_tests/*.gcda ${{github.workspace}}/build/tests/CMakeFiles/snatch_runtime_tests_self.dir/runtime_tests/*.gcda
         ls | grep '.gcov' | grep -v snatch | xargs -d"\n" rm
         bash <(curl -s https://codecov.io/bash)
 
     - name: Install
-      if: matrix.build-type == 'Release' && github.ref == 'refs/heads/main'
+      if: matrix.build-type == 'Release' && matrix.config.name == 'Default' && github.ref == 'refs/heads/main'
       working-directory: ${{github.workspace}}/build
       shell: bash
       run: cmake --build . --config ${{matrix.build-type}} --target install
 
     # In action-zip, all paths are relative to ${{github.workspace}}
     - name: Zip full build
-      if: matrix.build-type == 'Release' && github.ref == 'refs/heads/main'
+      if: matrix.build-type == 'Release' && matrix.config.name == 'Default' && github.ref == 'refs/heads/main'
       uses: vimtor/action-zip@v1
       with:
         files: install/ LICENSE
@@ -116,14 +120,14 @@ jobs:
 
     # In action-zip, all paths are relative to ${{github.workspace}}
     - name: Zip header-only
-      if: matrix.build-type == 'Release' && github.ref == 'refs/heads/main'
+      if: matrix.build-type == 'Release' && matrix.config.name == 'Default' && github.ref == 'refs/heads/main'
       uses: vimtor/action-zip@v1
       with:
         files: install/include/snatch/snatch_all.hpp LICENSE
         dest: snatch-header-only.zip
 
     - name: Upload build as an artifact
-      if: matrix.build-type == 'Release' && github.ref == 'refs/heads/main'
+      if: matrix.build-type == 'Release' && matrix.config.name == 'Default' && github.ref == 'refs/heads/main'
       uses: actions/upload-artifact@v2
       with:
         name: snatch-build

--- a/README.md
+++ b/README.md
@@ -175,21 +175,21 @@ Results for Debug builds:
 | **Debug**       | _snatch_ | _Catch2_ | _doctest_ | _Boost UT_ |
 |-----------------|----------|----------|-----------|------------|
 | Build framework | 1.8s     | 64s      | 2.0s      | 0s         |
-| Build tests     | 62s      | 86s      | 78s       | 109s       |
-| Build all       | 64s      | 150s     | 80s       | 109s       |
-| Run tests       | 23ms     | 83ms     | 60ms      | 20ms       |
+| Build tests     | 60s      | 86s      | 78s       | 109s       |
+| Build all       | 62s      | 150s     | 80s       | 109s       |
+| Run tests       | 21ms     | 83ms     | 60ms      | 20ms       |
 | Library size    | 2.90MB   | 38.6MB   | 2.8MB     | 0MB        |
-| Executable size | 32.4MB   | 49.3MB   | 38.6MB    | 51.9MB     |
+| Executable size | 31.9MB   | 49.3MB   | 38.6MB    | 51.9MB     |
 
 Results for Release builds:
 
 | **Release**     | _snatch_ | _Catch2_ | _doctest_ | _Boost UT_ |
 |-----------------|----------|----------|-----------|------------|
 | Build framework | 2.5s     | 68s      | 3.6s      | 0s         |
-| Build tests     | 136s     | 264s     | 216s      | 281s       |
-| Build all       | 139s     | 332s     | 220s      | 281s       |
-| Run tests       | 9ms      | 31ms     | 36ms      | 10ms       |
-| Library size    | 0.62MB   | 2.6MB    | 0.39MB    | 0MB        |
+| Build tests     | 138s     | 264s     | 216s      | 281s       |
+| Build all       | 140s     | 332s     | 220s      | 281s       |
+| Run tests       | 11ms     | 31ms     | 36ms      | 10ms       |
+| Library size    | 0.63MB   | 2.6MB    | 0.39MB    | 0MB        |
 | Executable size | 9.8MB    | 17.4MB   | 15.2MB    | 11.3MB     |
 
 Notes:

--- a/README.md
+++ b/README.md
@@ -174,21 +174,21 @@ Results for Debug builds:
 
 | **Debug**       | _snatch_ | _Catch2_ | _doctest_ | _Boost UT_ |
 |-----------------|----------|----------|-----------|------------|
-| Build framework | 1.7s     | 64s      | 2.0s      | 0s         |
-| Build tests     | 61s      | 86s      | 78s       | 109s       |
-| Build all       | 63s      | 150s     | 80s       | 109s       |
-| Run tests       | 17ms     | 83ms     | 60ms      | 20ms       |
-| Library size    | 2.80MB   | 38.6MB   | 2.8MB     | 0MB        |
-| Executable size | 32.3MB   | 49.3MB   | 38.6MB    | 51.9MB     |
+| Build framework | 1.8s     | 64s      | 2.0s      | 0s         |
+| Build tests     | 62s      | 86s      | 78s       | 109s       |
+| Build all       | 64s      | 150s     | 80s       | 109s       |
+| Run tests       | 23ms     | 83ms     | 60ms      | 20ms       |
+| Library size    | 2.90MB   | 38.6MB   | 2.8MB     | 0MB        |
+| Executable size | 32.4MB   | 49.3MB   | 38.6MB    | 51.9MB     |
 
 Results for Release builds:
 
 | **Release**     | _snatch_ | _Catch2_ | _doctest_ | _Boost UT_ |
 |-----------------|----------|----------|-----------|------------|
 | Build framework | 2.5s     | 68s      | 3.6s      | 0s         |
-| Build tests     | 135s     | 264s     | 216s      | 281s       |
-| Build all       | 137s     | 332s     | 220s      | 281s       |
-| Run tests       | 10ms     | 31ms     | 36ms      | 10ms       |
+| Build tests     | 136s     | 264s     | 216s      | 281s       |
+| Build all       | 139s     | 332s     | 220s      | 281s       |
+| Run tests       | 9ms      | 31ms     | 36ms      | 10ms       |
 | Library size    | 0.62MB   | 2.6MB    | 0.39MB    | 0MB        |
 | Executable size | 9.8MB    | 17.4MB   | 15.2MB    | 11.3MB     |
 

--- a/README.md
+++ b/README.md
@@ -692,12 +692,12 @@ int main(int argc, char* argv[]) {
 By default, _snatch_ assumes exceptions are enabled, and uses them in two cases:
 
  1. Obviously, in test macros that check exceptions being thrown (e.g., `REQUIRE_THROWS_AS(...)`).
- 2. In `REQUIRE_*()` or `FAIL()` macros, to abort execution of the current test case.
+ 2. In `REQUIRE_*()` or `FAIL()` macros, to abort execution of the current test case and continue to the next one.
 
 If _snatch_ detects that exceptions are not available (or is configured with exceptions disabled, by setting `SNATCH_WITH_EXCEPTIONS` to `0`), then
 
  1. Test macros that check exceptions being thrown will not be defined.
- 2. `REQUIRE_*()` and `FAIL()` macros will simply use `return` to abort execution. As a consequence, if these macros are used inside functions other than the test case function, they will only abort execution of the current function, and not of the actual test case. Therefore, these macros should only be used in the immediate body of the test case, or simply not at all.
+ 2. `REQUIRE_*()` and `FAIL()` macros will simply use `std::terminate()` to abort execution. As a consequence, if a `REQUIRE*()` or `FAIL()` check fails, the whole test application stops and the following test cases are not executed.
 
 
 ### Header-only build

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -1344,7 +1344,7 @@ bool operator==(const M& m, const T& value) noexcept {
 #    define SNATCH_TESTING_ABORT                                                                   \
         throw snatch::impl::abort_exception {}
 #else
-#    define SNATCH_TESTING_ABORT return
+#    define SNATCH_TESTING_ABORT std::terminate()
 #endif
 
 #define SNATCH_CONCAT_IMPL(x, y) x##y

--- a/include/snatch/snatch.hpp
+++ b/include/snatch/snatch.hpp
@@ -289,8 +289,8 @@ public:
 
 template<typename ElemType, std::size_t MaxLength>
 class small_vector {
-    std::array<ElemType, MaxLength> data_buffer;
-    std::size_t                     data_size = 0;
+    std::array<ElemType, MaxLength> data_buffer = {};
+    std::size_t                     data_size   = 0;
 
 public:
     constexpr small_vector() noexcept                          = default;
@@ -392,8 +392,8 @@ using small_string_view = small_vector_span<const char>;
 
 template<std::size_t MaxLength>
 class small_string {
-    std::array<char, MaxLength> data_buffer;
-    std::size_t                 data_size = 0u;
+    std::array<char, MaxLength> data_buffer = {};
+    std::size_t                 data_size   = 0u;
 
 public:
     constexpr small_string() noexcept                          = default;

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -1299,7 +1299,7 @@ void print_help(
 }
 
 // clang-format off
-const expected_arguments expected_args = {
+constexpr expected_arguments expected_args = {
     {{"-l", "--list-tests"},    {},                    "List tests by name"},
     {{"--list-tags"},           {},                    "List tags by name"},
     {{"--list-tests-with-tag"}, {"[tag]"},             "List tests by name with a given tag"},

--- a/tests/runtime_tests/registry.cpp
+++ b/tests/runtime_tests/registry.cpp
@@ -360,8 +360,8 @@ TEST_CASE("report REQUIRE_THROWS_AS", "[registry]") {
         framework.setup_reporter();
         framework.registry.run(test);
     }
-#endif
 };
+#endif
 
 TEST_CASE("report SKIP", "[registry]") {
     mock_framework framework;


### PR DESCRIPTION
This PR does the following:
 - Remove un-initialised data in `small_vector` and `small_string`, which removes all chances of undefined behavior (UB). The potential UB was preventing these classes from being used in `constexpr` settings. Closes #17.
 - When exceptions are disabled, all `REQUIRE*()` and `FAIL()` macros will call `std::terminate` instead of `return`, to ensure no further code in the test case is executed.