### PR TITLE
Use regular function for test case

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ TEST_CASE("Factorials are computed", "[factorial]" ) {
     REQUIRE( Factorial(2) == 2 );
     REQUIRE( Factorial(3) == 6 );
     REQUIRE( Factorial(10) == 3628800 );
-}; // note the required semicolon here: snatch test cases are expressions, not functions
+}
 ```
 
 Output:
@@ -85,7 +85,7 @@ using MyTypes = snatch::type_list<int, char, float>; // could also be std::tuple
 TEMPLATE_LIST_TEST_CASE("Template test case with test types specified inside snatch::type_list", "[template][list]", MyTypes)
 {
     REQUIRE(sizeof(TestType) > 1); // will fail for 'char'
-};
+}
 ```
 
 Output:
@@ -205,17 +205,17 @@ See [the dedicated page in the docs folder](doc/comparison_catch2.md).
 
 ### Test case macros
 
-`TEST_CASE(NAME, TAGS) { /* test body */ };`
+`TEST_CASE(NAME, TAGS) { /* test body */ }`
 
 This must be called at namespace, global, or class scope; not inside a function or another test case. This defines a new test case of name `NAME`. `NAME` must be a string literal, and may contain any character, up to a maximum length configured by `SNATCH_MAX_TEST_NAME_LENGTH` (default is `1024`). This name will be used to display test reports, and can be used to filter the tests. It is not required to be a unique name. `TAGS` specify which tag(s) are associated with this test case. This must be a string literal with the same limitations as `NAME`. See the [Tags](#tags) section for more information on tags. Finally, `test body` is the body of your test case. Within this scope, you can use the test macros listed [below](#test-check-macros).
 
 
-`TEMPLATE_TEST_CASE(NAME, TAGS, TYPES...) { /* test code for TestType */ };`
+`TEMPLATE_TEST_CASE(NAME, TAGS, TYPES...) { /* test code for TestType */ }`
 
 This is similar to `TEST_CASE`, except that it declares a new test case for each of the types listed in `TYPES...`. Within the test body, the current type can be accessed as `TestType`. If you tend to reuse the same list of types for multiple test cases, then `TEMPLATE_LIST_TEST_CASE()` is recommended instead.
 
 
-`TEMPLATE_LIST_TEST_CASE(NAME, TAGS, TYPES) { /* test code for TestType */ };`
+`TEMPLATE_LIST_TEST_CASE(NAME, TAGS, TYPES) { /* test code for TestType */ }`
 
 This is equivalent to `TEMPLATE_TEST_CASE`, except that `TYPES` must be a template type list of the form `T<Types...>`, for example `snatch::type_list<Types...>` or `std::tuple<Types...>`. This type list can be declared once and reused for multiple test cases.
 
@@ -385,7 +385,7 @@ TEST_CASE( "test with sections", "[section]" ) {
 
     std::cout << "tear-down" << std::endl;
     // shared tear-down logic here...
-};
+}
 ```
 
 The output of this test will be:
@@ -423,8 +423,7 @@ TEST_CASE("test without captures", "[captures]") {
     for (std::size_t i = 0; i < 10; ++i) {
         CHECK(std::abs(std::cos(i * 3.14159 / 10)) > 0.4);
     }
-};
-
+}
 ```
 
 The output of this test is:
@@ -451,8 +450,7 @@ TEST_CASE("test with captures", "[captures]") {
         CAPTURE(i);
         CHECK(std::abs(std::cos(i * 3.14159 / 10)) > 0.4);
     }
-};
-
+}
 ```
 
 This new test now outputs:
@@ -482,8 +480,7 @@ TEST_CASE("test with many captures", "[captures]") {
         CAPTURE(i, 2 * i, std::pow(i, 3.0f));
         CHECK(std::abs(std::cos(i * 3.14159 / 10)) > 0.2);
     }
-};
-
+}
 ```
 
 This outputs:
@@ -515,8 +512,7 @@ TEST_CASE("test with info", "[captures]") {
         CAPTURE(i);
         CHECK(std::abs(std::cos(i * 3.14159 / 10)) > 0.2);
     }
-};
-
+}
 ```
 
 This outputs:
@@ -684,6 +680,7 @@ int main(int argc, char* argv[]) {
     // Actually run the tests.
     // This will apply any filtering specified on the command line.
     return snatch::tests.run_tests(*args) ? 0 : 1;
+}
 ```
 
 

--- a/src/snatch.cpp
+++ b/src/snatch.cpp
@@ -643,7 +643,11 @@ small_vector<std::string_view, max_captures> make_capture_buffer(const capture_s
 } // namespace
 
 namespace snatch {
-void registry::register_test(const test_id& id, test_ptr func) noexcept {
+const char* registry::add(std::string_view name, std::string_view tags, test_ptr func) noexcept {
+    return add({name, tags, {}}, func);
+}
+
+const char* registry::add(const test_id& id, test_ptr func) noexcept {
     if (test_list.size() == test_list.capacity()) {
         print(
             make_colored("error:", with_color, color::fail),
@@ -664,6 +668,8 @@ void registry::register_test(const test_id& id, test_ptr func) noexcept {
             max_test_name_length, ")\n.");
         std::terminate();
     }
+
+    return id.name.data();
 }
 
 void registry::print_location(

--- a/tests/runtime_tests/capture.cpp
+++ b/tests/runtime_tests/capture.cpp
@@ -171,7 +171,7 @@ TEST_CASE("capture", "[test macros]") {
         CHECK_CAPTURES_FOR_FAILURE(0u, "i := 1");
         CHECK_CAPTURES_FOR_FAILURE(1u, "i := 1", "2 * i := 2");
     }
-};
+}
 
 TEST_CASE("info", "[test macros]") {
     mock_framework framework;
@@ -324,6 +324,6 @@ TEST_CASE("info", "[test macros]") {
         framework.run_test();
         CHECK_CAPTURES("1", "i := 1");
     }
-};
+}
 
 SNATCH_WARNING_POP

--- a/tests/runtime_tests/check.cpp
+++ b/tests/runtime_tests/check.cpp
@@ -439,7 +439,7 @@ TEST_CASE("check unary", "[test macros]") {
         CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
         CHECK(event.message == "CHECK(2 % value), got 0"sv);
     }
-};
+}
 
 TEST_CASE("check binary", "[test macros]") {
     snatch::registry mock_registry;
@@ -702,7 +702,7 @@ TEST_CASE("check binary", "[test macros]") {
         CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
         CHECK(event.message == "CHECK(value1 >= value2), got 0 < 1"sv);
     }
-};
+}
 
 TEST_CASE("check false", "[test macros]") {
     snatch::registry mock_registry;
@@ -800,7 +800,7 @@ TEST_CASE("check false", "[test macros]") {
             event.message ==
             "CHECK_FALSE(\"hello\"sv == snatch::matchers::contains_substring{\"lo\"}), got found 'lo' in 'hello'"sv);
     }
-};
+}
 
 TEST_CASE("check misc", "[test macros]") {
     snatch::registry mock_registry;
@@ -1080,4 +1080,4 @@ TEST_CASE("check misc", "[test macros]") {
             event.message ==
             "CHECK(\"hello\"sv == snatch::matchers::contains_substring{\"foo\"}), got could not find 'foo' in 'hello'"sv);
     }
-};
+}

--- a/tests/runtime_tests/cli.cpp
+++ b/tests/runtime_tests/cli.cpp
@@ -14,7 +14,7 @@ TEST_CASE("parse arguments empty", "[cli]") {
     CHECK(input->executable == "test"sv);
     CHECK(input->arguments.empty());
     CHECK(console.messages.empty());
-};
+}
 
 TEST_CASE("parse arguments empty .exe", "[cli]") {
     console_output_catcher console;
@@ -26,7 +26,7 @@ TEST_CASE("parse arguments empty .exe", "[cli]") {
     CHECK(input->executable == "test"sv);
     CHECK(input->arguments.empty());
     CHECK(console.messages.empty());
-};
+}
 
 TEST_CASE("parse arguments empty .something.exe", "[cli]") {
     console_output_catcher console;
@@ -38,7 +38,7 @@ TEST_CASE("parse arguments empty .something.exe", "[cli]") {
     CHECK(input->executable == "test.something"sv);
     CHECK(input->arguments.empty());
     CHECK(console.messages.empty());
-};
+}
 
 TEST_CASE("parse arguments help (long form)", "[cli]") {
     console_output_catcher console;
@@ -53,7 +53,7 @@ TEST_CASE("parse arguments help (long form)", "[cli]") {
     CHECK(!input->arguments[0].value.has_value());
     CHECK(!input->arguments[0].value_name.has_value());
     CHECK(console.messages.empty());
-};
+}
 
 TEST_CASE("parse arguments help (short form)", "[cli]") {
     console_output_catcher console;
@@ -68,7 +68,7 @@ TEST_CASE("parse arguments help (short form)", "[cli]") {
     CHECK(!input->arguments[0].value.has_value());
     CHECK(!input->arguments[0].value_name.has_value());
     CHECK(console.messages.empty());
-};
+}
 
 TEST_CASE("parse arguments help (duplicate)", "[cli]") {
     console_output_catcher console;
@@ -78,7 +78,7 @@ TEST_CASE("parse arguments help (duplicate)", "[cli]") {
 
     REQUIRE(!input.has_value());
     CHECK(console.messages == contains_substring("duplicate command line argument '--help'"));
-};
+}
 
 TEST_CASE("parse arguments verbosity (long form)", "[cli]") {
     console_output_catcher console;
@@ -95,7 +95,7 @@ TEST_CASE("parse arguments verbosity (long form)", "[cli]") {
     CHECK(input->arguments[0].value.value() == "high"sv);
     CHECK(input->arguments[0].value_name.value() == "quiet|normal|high"sv);
     CHECK(console.messages.empty());
-};
+}
 
 TEST_CASE("parse arguments verbosity (short form)", "[cli]") {
     console_output_catcher console;
@@ -112,7 +112,7 @@ TEST_CASE("parse arguments verbosity (short form)", "[cli]") {
     CHECK(input->arguments[0].value.value() == "high"sv);
     CHECK(input->arguments[0].value_name.value() == "quiet|normal|high"sv);
     CHECK(console.messages.empty());
-};
+}
 
 TEST_CASE("parse arguments verbosity (no value)", "[cli]") {
     console_output_catcher console;
@@ -125,7 +125,7 @@ TEST_CASE("parse arguments verbosity (no value)", "[cli]") {
         console.messages ==
         contains_substring(
             "missing value '<quiet|normal|high>' for command line argument '--verbosity'"));
-};
+}
 
 TEST_CASE("parse arguments unknown", "[cli]") {
     console_output_catcher console;
@@ -137,7 +137,7 @@ TEST_CASE("parse arguments unknown", "[cli]") {
     CHECK(input->executable == "test"sv);
     CHECK(input->arguments.empty());
     CHECK(console.messages == contains_substring("unknown command line argument '--make-coffee'"));
-};
+}
 
 TEST_CASE("parse arguments positional", "[cli]") {
     console_output_catcher console;
@@ -154,7 +154,7 @@ TEST_CASE("parse arguments positional", "[cli]") {
     CHECK(input->arguments[0].value.value() == "arg1"sv);
     CHECK(input->arguments[0].value_name.value() == "test regex"sv);
     CHECK(console.messages.empty());
-};
+}
 
 TEST_CASE("parse arguments too many positional", "[cli]") {
     console_output_catcher console;
@@ -164,7 +164,7 @@ TEST_CASE("parse arguments too many positional", "[cli]") {
 
     REQUIRE(!input.has_value());
     CHECK(console.messages == contains_substring("too many positional arguments"));
-};
+}
 
 TEST_CASE("get option", "[cli]") {
     const arg_vector args = {"test", "--help", "--verbosity", "high"};
@@ -191,7 +191,7 @@ TEST_CASE("get option", "[cli]") {
 
     auto short_help_option = snatch::cli::get_option(*input, "-v");
     CHECK(!short_help_option.has_value());
-};
+}
 
 TEST_CASE("get positional argument", "[cli]") {
     SECTION("good") {
@@ -234,4 +234,4 @@ TEST_CASE("get positional argument", "[cli]") {
             CHECK(!arg.has_value());
         }
     }
-};
+}

--- a/tests/runtime_tests/matchers.cpp
+++ b/tests/runtime_tests/matchers.cpp
@@ -48,7 +48,7 @@ TEST_CASE("example matcher has_prefix", "[utility]") {
         snatch::matchers::has_prefix{"warning"}.describe_match(
             "info: hello"sv, snatch::matchers::match_status::failed) ==
         "could not find prefix 'warning:' in 'info: hello'; found prefix 'info:'"sv);
-};
+}
 
 TEST_CASE("matcher contains_substring", "[utility]") {
     CHECK("info: hello"sv == snatch::matchers::contains_substring{"hello"});
@@ -64,7 +64,7 @@ TEST_CASE("matcher contains_substring", "[utility]") {
         snatch::matchers::contains_substring{"warning"}.describe_match(
             "info: hello"sv, snatch::matchers::match_status::failed) ==
         "could not find 'warning' in 'info: hello'"sv);
-};
+}
 
 TEST_CASE("matcher with_what_contains", "[utility]") {
     CHECK(std::runtime_error{"not good"} == snatch::matchers::with_what_contains{"good"});
@@ -84,7 +84,7 @@ TEST_CASE("matcher with_what_contains", "[utility]") {
         snatch::matchers::with_what_contains{"bad"}.describe_match(
             std::runtime_error{"not good"}, snatch::matchers::match_status::failed) ==
         "could not find 'bad' in 'not good'"sv);
-};
+}
 
 TEST_CASE("matcher is_any_of", "[utility]") {
     const auto m = snatch::matchers::is_any_of{1u, 2u, 3u};
@@ -108,4 +108,4 @@ TEST_CASE("matcher is_any_of", "[utility]") {
     CHECK(
         m.describe_match(5u, snatch::matchers::match_status::failed) ==
         "'5' was not found in {'1', '2', '3'}"sv);
-};
+}

--- a/tests/runtime_tests/skip.cpp
+++ b/tests/runtime_tests/skip.cpp
@@ -49,6 +49,6 @@ TEST_CASE("skip", "[test macros]") {
         CHECK(framework.get_num_skips() == 1u);
         CHECK(framework.get_num_failures() == 0u);
     }
-};
+}
 
 SNATCH_WARNING_POP

--- a/tests/runtime_tests/small_function.cpp
+++ b/tests/runtime_tests/small_function.cpp
@@ -168,4 +168,4 @@ TEMPLATE_TEST_CASE(
             CHECK(test_object_instances <= expected_instances);
         }
     }(type_holder<TestType>{});
-};
+}

--- a/tests/runtime_tests/small_string.cpp
+++ b/tests/runtime_tests/small_string.cpp
@@ -363,7 +363,7 @@ TEMPLATE_TEST_CASE("small string", "[utility]", string_type, span_type, view_typ
             CHECK(sv[2] == 'c');
         }
     }
-};
+}
 
 // This requires fixing https://github.com/cschreib/snatch/issues/17
 // TEST_CASE("constexpr small string", "[utility]") {

--- a/tests/runtime_tests/small_vector.cpp
+++ b/tests/runtime_tests/small_vector.cpp
@@ -387,7 +387,7 @@ TEMPLATE_TEST_CASE("small vector", "[utility]", vector_type, span_type, const_sp
         CHECK(v[1].b == false);
         CHECK(v[2].b == false);
     }
-};
+}
 
 TEST_CASE("constexpr small vector test_struct", "[utility]") {
     using TestType = vector_type;
@@ -438,7 +438,7 @@ TEST_CASE("constexpr small vector test_struct", "[utility]") {
         CHECK(v[1].b == false);
         CHECK(v[2].b == false);
     }
-};
+}
 
 // This requires fixing https://github.com/cschreib/snatch/issues/17
 // TEST_CASE("constexpr small vector int", "[utility]") {

--- a/tests/runtime_tests/string_utility.cpp
+++ b/tests/runtime_tests/string_utility.cpp
@@ -112,7 +112,7 @@ TEMPLATE_TEST_CASE(
         CHECK(!append(s, value));
         CHECK(std::string_view(s) == initial);
     }
-};
+}
 
 TEST_CASE("append multiple", "[utility]") {
     string_type s;
@@ -141,7 +141,7 @@ TEST_CASE("append multiple", "[utility]") {
         CHECK(!append(s, "int=", 123456, ", bool=", true));
         CHECK(std::string_view(s) == "int=123456, bool=tru"sv);
     }
-};
+}
 
 TEMPLATE_TEST_CASE(
     "truncate_end",
@@ -186,7 +186,7 @@ TEMPLATE_TEST_CASE(
             CHECK(std::string_view(s) == "..."sv.substr(0, s.size()));
         }
     }
-};
+}
 
 TEMPLATE_TEST_CASE(
     "append_or_truncate",
@@ -210,7 +210,7 @@ TEMPLATE_TEST_CASE(
     } else {
         CHECK(std::string_view(s) == "..."sv.substr(0, s.capacity()));
     }
-};
+}
 
 TEMPLATE_TEST_CASE(
     "replace_all",
@@ -352,4 +352,4 @@ TEMPLATE_TEST_CASE(
         CHECK(replace_all(s, "abacaabcdefghijklmqrst", "abcdefghijklmnopqrstabcdefghijklmnopqrst"));
         CHECK(std::string_view(s) == "abaca");
     }
-};
+}

--- a/tests/runtime_tests/type_name.cpp
+++ b/tests/runtime_tests/type_name.cpp
@@ -36,4 +36,4 @@ TEST_CASE("type name", "[utility]") {
         snatch::matchers::is_any_of("global_test_struct"sv, "struct global_test_struct"sv));
 
     CHECK(snatch::type_name<test_struct>.ends_with("test_struct"));
-};
+}


### PR DESCRIPTION
This PR allows defining `TEST_CASE*` without a trailing semicolon, for ease of use and portability from _Catch2_.