### PR TITLE
Allow `REQUIRE()` and `CHECK()` even on non-decomposable expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,11 +175,11 @@ Results for Debug builds:
 | **Debug**       | _snatch_ | _Catch2_ | _doctest_ | _Boost UT_ |
 |-----------------|----------|----------|-----------|------------|
 | Build framework | 1.7s     | 64s      | 2.0s      | 0s         |
-| Build tests     | 60s      | 86s      | 78s       | 109s       |
-| Build all       | 62s      | 150s     | 80s       | 109s       |
+| Build tests     | 62s      | 86s      | 78s       | 109s       |
+| Build all       | 64s      | 150s     | 80s       | 109s       |
 | Run tests       | 21ms     | 83ms     | 60ms      | 20ms       |
 | Library size    | 2.90MB   | 38.6MB   | 2.8MB     | 0MB        |
-| Executable size | 32.5MB   | 49.3MB   | 38.6MB    | 51.9MB     |
+| Executable size | 32.7MB   | 49.3MB   | 38.6MB    | 51.9MB     |
 
 Results for Release builds:
 

--- a/tests/runtime_tests/check.cpp
+++ b/tests/runtime_tests/check.cpp
@@ -94,6 +94,9 @@ struct long_matcher_always_fails {
 };
 } // namespace snatch::matchers
 
+SNATCH_WARNING_PUSH
+SNATCH_WARNING_DISABLE_INT_BOOLEAN
+
 TEST_CASE("check unary", "[test macros]") {
     snatch::registry mock_registry;
 
@@ -441,6 +444,8 @@ TEST_CASE("check unary", "[test macros]") {
     }
 }
 
+SNATCH_WARNING_POP
+
 TEST_CASE("check binary", "[test macros]") {
     snatch::registry mock_registry;
 
@@ -725,7 +730,32 @@ TEST_CASE("check binary", "[test macros]") {
 
         CHECK_EVENT_TEST_ID(event, mock_case.id);
         CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
-        CHECK(event.message == "CHECK(value1 <=> value2 != 0), got ? == 0"sv);
+        CHECK(event.message == "CHECK(value1 <=> value2 != 0)"sv);
+    }
+
+    SECTION("complex expression") {
+        int         value1       = 1;
+        int         value2       = 1;
+        std::size_t failure_line = 0u;
+
+        {
+            test_override override(mock_run);
+            // clang-format off
+            SNATCH_CHECK(value1 == 1 && value2 == 0); failure_line = __LINE__;
+            // clang-format on
+        }
+
+        CHECK(value1 == 1);
+        CHECK(value2 == 1);
+        CHECK(mock_run.asserts == 1u);
+
+        REQUIRE(last_event.has_value());
+        const auto& event = last_event.value();
+        CHECK(event.event_type == event_deep_copy::type::assertion_failed);
+
+        CHECK_EVENT_TEST_ID(event, mock_case.id);
+        CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
+        CHECK(event.message == "CHECK(value1 == 1 && value2 == 0)"sv);
     }
 }
 

--- a/tests/runtime_tests/check.cpp
+++ b/tests/runtime_tests/check.cpp
@@ -702,6 +702,31 @@ TEST_CASE("check binary", "[test macros]") {
         CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
         CHECK(event.message == "CHECK(value1 >= value2), got 0 < 1"sv);
     }
+
+    SECTION("spaceship") {
+        int         value1       = 1;
+        int         value2       = 1;
+        std::size_t failure_line = 0u;
+
+        {
+            test_override override(mock_run);
+            // clang-format off
+            SNATCH_CHECK(value1 <=> value2 != 0); failure_line = __LINE__;
+            // clang-format on
+        }
+
+        CHECK(value1 == 1);
+        CHECK(value2 == 1);
+        CHECK(mock_run.asserts == 1u);
+
+        REQUIRE(last_event.has_value());
+        const auto& event = last_event.value();
+        CHECK(event.event_type == event_deep_copy::type::assertion_failed);
+
+        CHECK_EVENT_TEST_ID(event, mock_case.id);
+        CHECK_EVENT_LOCATION(event, __FILE__, failure_line);
+        CHECK(event.message == "CHECK(value1 <=> value2 != 0), got ? == 0"sv);
+    }
 }
 
 TEST_CASE("check false", "[test macros]") {

--- a/tests/testing.hpp
+++ b/tests/testing.hpp
@@ -41,10 +41,15 @@ struct filldata<T*> {
 
 #if defined(__clang__)
 #    define SNATCH_WARNING_DISABLE_UNREACHABLE
+#    define SNATCH_WARNING_DISABLE_INT_BOOLEAN
 #elif defined(__GNUC__)
 #    define SNATCH_WARNING_DISABLE_UNREACHABLE
+#    define SNATCH_WARNING_DISABLE_INT_BOOLEAN                                                     \
+        _Pragma("GCC diagnostic ignored \"-Wint-in-bool-context\"")
 #elif defined(_MSC_VER)
 #    define SNATCH_WARNING_DISABLE_UNREACHABLE _Pragma("warning(disable: 4702)")
+#    define SNATCH_WARNING_DISABLE_INT_BOOLEAN
 #else
 #    define SNATCH_WARNING_DISABLE_UNREACHABLE
+#    define SNATCH_WARNING_DISABLE_INT_BOOLEAN
 #endif


### PR DESCRIPTION
This PR improves the `REQUIRE*()` and `CHECK*()` macros so that all expressions (contextually convertible to bool, as in `if (expr)`) are supported, even if they cannot be decomposed.

Closes #43.